### PR TITLE
Add 'tail_quantiles' method for HeatFlowAnomalyPosterior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.1.0] - 2022-11-29
+#### Added
+- Added the `tail_quantiles` method of the `HeatFlowAnomalyPosterior` class.
+  This computes the quantiles for the batch-evaluated CDF.
+
 ### [1.0.1] - 2022-11-28
 #### Changed
 - Fix a C++ standard incompatibility that is compatible with g++ but

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = 'REHEATFUNQ'
 copyright = '2022, Deutsches GeoForschungsZentrum Potsdam & Malte J. Ziebarth'
 author = 'Malte J. Ziebarth'
-release = '1.0.1'
+release = '1.1.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/external/pdtoolbox/include/ziebarth2022a.hpp
+++ b/external/pdtoolbox/include/ziebarth2022a.hpp
@@ -3,7 +3,8 @@
  *
  * Author: Malte J. Ziebarth (ziebarth@gfz-potsdam.de)
  *
- * Copyright (C) 2021-2022 Deutsches GeoForschungsZentrum GFZ
+ * Copyright (C) 2021-2022 Deutsches GeoForschungsZentrum GFZ,
+ *                    2022 Malte J. Ziebarth
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -82,6 +83,14 @@ void tail_quantiles(const double* quantiles, double* res, const size_t Nquant,
                     const double* qi, const double* ci, const size_t N,
                     const double p, const double s, const double n,
                     const double nu, const double dest_tol);
+
+void posterior_tail_quantiles_batch(
+                    const double* quantiles, double* res, const size_t Nquant,
+                    const std::vector<const double*>& qi,
+                    const std::vector<const double*>& ci,
+                    const std::vector<size_t>& N,
+                    double p, double s, double n, double nu,
+                    double dest_tol);
 
 int tail_quantiles_intcode(const double* quantiles, double* res,
                            const size_t Nquant, const double* qi,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ data_distancedist   = MesonExtension('reheatfunq.data.distancedistribution')
 
 
 setup(name='REHEATFUNQ',
-      version='1.0.1',
+      version='1.1.0',
       author='Malte J. Ziebarth',
       description='',
       packages = ['reheatfunq','reheatfunq.regional','reheatfunq.anomaly',


### PR DESCRIPTION
This adds a missing functionality from the `ziebarth_et_al_2022_heatflow` module and augments
it with the bootstrapping functionality of the exclusive heat flow samples.