### PR TITLE
Dev highprecision

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,48 @@
+name: Testing
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    - *
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      max-parallel: 1
+      matrix:
+        python-version: [3.10]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Build REHEATFUNQ
+      run: |
+          sudo apt-get install -y libproj-dev libboost-dev libeigen3-dev \
+                                  libcgal-dev libgeographic-dev build-essential\
+                                  git openssh-client ssh cython3 \
+                                  python3-sphinx ninja-build cmake-data \
+                                  cmake-extras extra-cmake-modules \
+                                  python3-numpy
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+          pip install matplotlib pyproj meson scipy
+          pip install 'mebuex @ git+https://github.com/mjziebarth/Mebuex'
+          pip install 'loaducerf3 @ git+https://git.gfz-potsdam.de/ziebarth/loaducerf3'
+          bash compile.sh
+          pip install --user .
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        # Run the test suite:
+        cd testing
+        pytest

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ and this project adheres to
 - Added different working precisions for the heat flow anomaly strength
   quantification.
 - Make `gamma_mle` method available in `reheatfunq.regional`.
+- Added `pytest` testing.
+- Added missing import in `jupyter/REHEATFUNQ/zeahl22hf/geojson.py`.
+
+#### Changed
+- Fix typo leading to incomplete quadrature error estimate in `outer_integrand`.
+- Use precision-dependent tolerance in heat flow anomaly posterior quadrature.
+- Add Kahan summation for heat flow anomaly posterior locals.
 
 
 ### [1.1.1] - 2022-12-02

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [Unreleased]
+#### Added
+- Added different working precisions for the heat flow anomaly strength
+  quantification.
+
+
 ### [1.1.1] - 2022-12-02
 #### Changed
 - Update REHEATFUNQ Jupyter notebooks, mainly unified figure aesthetics.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ and this project adheres to
 #### Added
 - Added different working precisions for the heat flow anomaly strength
   quantification.
+- Make `gamma_mle` method available in `reheatfunq.regional`.
 
 
 ### [1.1.1] - 2022-12-02

--- a/compile.sh
+++ b/compile.sh
@@ -8,4 +8,5 @@ if [ ! -d builddir ]; then
 fi
 
 cd builddir
+meson configure -Danomaly_posterior_dec50=true
 meson compile

--- a/external/pdtoolbox/include/ziebarth2022a.hpp
+++ b/external/pdtoolbox/include/ziebarth2022a.hpp
@@ -39,50 +39,50 @@ enum posterior_t {
 
 void posterior_pdf(const double* x, double* res, size_t Nx, const double* qi,
                    const double* ci, size_t N, double p, double s, double n,
-                   double nu, double dest_tol);
+                   double nu, double amin, double dest_tol);
 
 void posterior_pdf_batch(const double* x, size_t Nx, double* res,
                          const std::vector<const double*>& qi,
                          const std::vector<const double*>& ci,
                          const std::vector<size_t>& N,
                          double p, double s, double n, double nu,
-                         double dest_tol);
+                         double amin, double dest_tol);
 
 void posterior_cdf(const double* x, double* res, size_t Nx, const double* qi,
                    const double* ci, size_t N, double p, double s, double n,
-                   double nu, double dest_tol);
+                   double nu, double amin, double dest_tol);
 
 void posterior_cdf_batch(const double* x, size_t Nx, double* res,
                          const std::vector<const double*>& qi,
                          const std::vector<const double*>& ci,
                          const std::vector<size_t>& N,
                          double p, double s, double n, double nu,
-                         double dest_tol);
+                         double amin, double dest_tol);
 
 void posterior_tail(const double* x, double* res, size_t Nx, const double* qi,
                     const double* ci, size_t N, double p, double s, double n,
-                    double nu, double dest_tol);
+                    double nu, double amin, double dest_tol);
 
 void posterior_tail_batch(const double* x, size_t Nx, double* res,
                           const std::vector<const double*>& qi,
                           const std::vector<const double*>& ci,
                           const std::vector<size_t>& N,
                           double p, double s, double n, double nu,
-                          double dest_tol);
+                          double amin, double dest_tol);
 
 void posterior_log_unnormed(const double* x, double* res, size_t Nx,
                             const double* qi, const double* ci, size_t N,
                             double p, double s, double n, double nu,
-                            double dest_tol);
+                            double amin, double dest_tol);
 
 void posterior_silent(const double* x, double* res, size_t Nx, const double* qi,
                const double* ci, size_t N, double p, double s, double n,
-               double nu, double dest_tol, posterior_t type);
+               double nu, double amin, double dest_tol, posterior_t type);
 
 void tail_quantiles(const double* quantiles, double* res, const size_t Nquant,
                     const double* qi, const double* ci, const size_t N,
                     const double p, const double s, const double n,
-                    const double nu, const double dest_tol);
+                    const double nu, const double amin, const double dest_tol);
 
 void posterior_tail_quantiles_batch(
                     const double* quantiles, double* res, const size_t Nquant,
@@ -90,13 +90,13 @@ void posterior_tail_quantiles_batch(
                     const std::vector<const double*>& ci,
                     const std::vector<size_t>& N,
                     double p, double s, double n, double nu,
-                    double dest_tol);
+                    double amin, double dest_tol);
 
 int tail_quantiles_intcode(const double* quantiles, double* res,
                            const size_t Nquant, const double* qi,
                            const double* ci, const size_t N, const double p,
                            const double s, const double n, const double nu,
-                           const double dest_tol,
+                           const double amin, const double dest_tol,
                            short print);
 
 }

--- a/external/pdtoolbox/include/ziebarth2022a.hpp
+++ b/external/pdtoolbox/include/ziebarth2022a.hpp
@@ -37,47 +37,49 @@ enum posterior_t {
 	UNNORMED_LOG = 4
 };
 
-void posterior_pdf(const double* x, double* res, size_t Nx, const double* qi,
-                   const double* ci, size_t N, double p, double s, double n,
-                   double nu, double amin, double dest_tol);
+void posterior_pdf(const double* x, long double* res, size_t Nx,
+                   const double* qi, const double* ci, size_t N, double p,
+                   double s, double n, double nu, double amin, double dest_tol);
 
-void posterior_pdf_batch(const double* x, size_t Nx, double* res,
+void posterior_pdf_batch(const double* x, size_t Nx, long double* res,
                          const std::vector<const double*>& qi,
                          const std::vector<const double*>& ci,
                          const std::vector<size_t>& N,
                          double p, double s, double n, double nu,
                          double amin, double dest_tol);
 
-void posterior_cdf(const double* x, double* res, size_t Nx, const double* qi,
-                   const double* ci, size_t N, double p, double s, double n,
-                   double nu, double amin, double dest_tol);
+void posterior_cdf(const double* x, long double* res, size_t Nx,
+                   const double* qi, const double* ci, size_t N, double p,
+                   double s, double n, double nu, double amin, double dest_tol);
 
-void posterior_cdf_batch(const double* x, size_t Nx, double* res,
+void posterior_cdf_batch(const double* x, size_t Nx, long double* res,
                          const std::vector<const double*>& qi,
                          const std::vector<const double*>& ci,
                          const std::vector<size_t>& N,
                          double p, double s, double n, double nu,
                          double amin, double dest_tol);
 
-void posterior_tail(const double* x, double* res, size_t Nx, const double* qi,
-                    const double* ci, size_t N, double p, double s, double n,
-                    double nu, double amin, double dest_tol);
+void posterior_tail(const double* x, long double* res, size_t Nx,
+                    const double* qi, const double* ci, size_t N, double p,
+                    double s, double n, double nu, double amin,
+                    double dest_tol);
 
-void posterior_tail_batch(const double* x, size_t Nx, double* res,
+void posterior_tail_batch(const double* x, size_t Nx, long double* res,
                           const std::vector<const double*>& qi,
                           const std::vector<const double*>& ci,
                           const std::vector<size_t>& N,
                           double p, double s, double n, double nu,
                           double amin, double dest_tol);
 
-void posterior_log_unnormed(const double* x, double* res, size_t Nx,
+void posterior_log_unnormed(const double* x, long double* res, size_t Nx,
                             const double* qi, const double* ci, size_t N,
                             double p, double s, double n, double nu,
                             double amin, double dest_tol);
 
-void posterior_silent(const double* x, double* res, size_t Nx, const double* qi,
-               const double* ci, size_t N, double p, double s, double n,
-               double nu, double amin, double dest_tol, posterior_t type);
+void posterior_silent(const double* x, long double* res, size_t Nx,
+                      const double* qi, const double* ci, size_t N, double p,
+                      double s, double n, double nu, double amin,
+                      double dest_tol, posterior_t type);
 
 void tail_quantiles(const double* quantiles, double* res, const size_t Nquant,
                     const double* qi, const double* ci, const size_t N,

--- a/external/pdtoolbox/include/ziebarth2022a.hpp
+++ b/external/pdtoolbox/include/ziebarth2022a.hpp
@@ -37,49 +37,65 @@ enum posterior_t {
 	UNNORMED_LOG = 4
 };
 
+enum precision_t {
+	WP_DOUBLE = 0,
+	WP_LONG_DOUBLE = 1,
+	WP_FLOAT_128 = 2,
+	WP_BOOST_DEC_50 = 3,
+	WP_BOOST_DEC_100 = 4
+};
+
 void posterior_pdf(const double* x, long double* res, size_t Nx,
                    const double* qi, const double* ci, size_t N, double p,
-                   double s, double n, double nu, double amin, double dest_tol);
+                   double s, double n, double nu, double amin, double dest_tol,
+                   precision_t working_precision);
 
 void posterior_pdf_batch(const double* x, size_t Nx, long double* res,
                          const std::vector<const double*>& qi,
                          const std::vector<const double*>& ci,
                          const std::vector<size_t>& N,
                          double p, double s, double n, double nu,
-                         double amin, double dest_tol);
+                         double amin, double dest_tol,
+                         precision_t working_precision);
 
 void posterior_cdf(const double* x, long double* res, size_t Nx,
                    const double* qi, const double* ci, size_t N, double p,
-                   double s, double n, double nu, double amin, double dest_tol);
+                   double s, double n, double nu, double amin, double dest_tol,
+                   precision_t working_precision);
 
 void posterior_cdf_batch(const double* x, size_t Nx, long double* res,
                          const std::vector<const double*>& qi,
                          const std::vector<const double*>& ci,
                          const std::vector<size_t>& N,
                          double p, double s, double n, double nu,
-                         double amin, double dest_tol);
+                         double amin, double dest_tol,
+                         precision_t working_precision);
 
 void posterior_tail(const double* x, long double* res, size_t Nx,
                     const double* qi, const double* ci, size_t N, double p,
                     double s, double n, double nu, double amin,
-                    double dest_tol);
+                    double dest_tol,
+                    precision_t working_precision);
 
 void posterior_tail_batch(const double* x, size_t Nx, long double* res,
                           const std::vector<const double*>& qi,
                           const std::vector<const double*>& ci,
                           const std::vector<size_t>& N,
                           double p, double s, double n, double nu,
-                          double amin, double dest_tol);
+                          double amin, double dest_tol,
+                          precision_t working_precision);
 
 void posterior_log_unnormed(const double* x, long double* res, size_t Nx,
                             const double* qi, const double* ci, size_t N,
                             double p, double s, double n, double nu,
-                            double amin, double dest_tol);
+                            double amin, double dest_tol,
+                            precision_t working_precision);
 
 void posterior_silent(const double* x, long double* res, size_t Nx,
                       const double* qi, const double* ci, size_t N, double p,
                       double s, double n, double nu, double amin,
-                      double dest_tol, posterior_t type);
+                      double dest_tol, posterior_t type,
+                      precision_t working_precision);
 
 void tail_quantiles(const double* quantiles, double* res, const size_t Nquant,
                     const double* qi, const double* ci, const size_t N,

--- a/external/pdtoolbox/src/ziebarth2022a.cpp
+++ b/external/pdtoolbox/src/ziebarth2022a.cpp
@@ -38,6 +38,8 @@
 #include <boost/math/quadrature/gauss_kronrod.hpp>
 #include <boost/math/quadrature/gauss.hpp>
 #include <boost/math/tools/roots.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/multiprecision/float128.hpp>
 #include <algorithm>
 #include <iostream>
 
@@ -59,15 +61,30 @@ using pdtoolbox::QuantileInverter;
 using pdtoolbox::OR;
 using pdtoolbox::AND;
 using pdtoolbox::cnst_sqrt;
+/*
+ * Use a high precision floating point format.
+ */
+#ifdef REHEATFUNQ_ANOMALY_POSTERIOR_TYPE_QUAD
+using boost::multiprecision::float128;
+typedef float128 real_t;
+#else
+typedef long double float128;
+typedef long double real_t;
+#endif
 
-typedef gauss_kronrod<double, 15> GK;
+
+/* tanh_sinh tolerance: */
+constexpr double TOL_TANH_SINH
+     = cnst_sqrt(std::numeric_limits<double>::epsilon());
+
 
 /* A custom exception type indicating that the integral is out of
  * scale for double precision: */
+template<typename real>
 class ScaleError : public std::exception
 {
 public:
-	explicit ScaleError(const char* msg, double log_scale)
+	explicit ScaleError(const char* msg, real log_scale)
 	    : _lscale(log_scale), msg(msg) {};
 
 	virtual const char* what() const noexcept
@@ -75,34 +92,37 @@ public:
 		return msg;
 	}
 
-	double log_scale() const
+	real log_scale() const
 	{
 		return _lscale;
 	};
 
 private:
-	double _lscale;
+	real _lscale;
 	const char* msg;
 };
 
 
+template<typename real>
 class PrecisionError : public std::exception
 {
 public:
-	explicit PrecisionError(const char* msg, double error, double L1)
-	    : _error(error), _L1(L1), msg(generate_message(msg, error, L1)) {};
+	explicit PrecisionError(const char* msg, real error, real L1)
+	    : _error(error), _L1(L1),
+	      msg(generate_message(msg, static_cast<double>(error),
+	                           static_cast<double>(L1))) {};
 
 	virtual const char* what() const noexcept
 	{
 		return msg.c_str();
 	}
 
-	double error() const
+	real error() const
 	{
 		return _error;
 	};
 
-	double L1() const
+	real L1() const
 	{
 		return _L1;
 	};
@@ -149,50 +169,79 @@ private:
  * assuming constant z):
  */
 
-static double log_integrand_amax(double v, double lp, double n, double ls,
-                                 double l1pwz, double lkiz_sum)
+template<typename real>
+real log_integrand_amax(const real v, const real lp, const real n,
+                        const real ls, const real l1pwz, const real lkiz_sum)
 {
+	using std::abs;
+	using boost::multiprecision::abs;
+
 	/* Uses Newton-Raphson to compute the (approximate) maximum of the
 	 * integrand (disregarding the second integral) of the normalization
 	 * of the posterior.
 	 */
-	const double C = lp - v*(ls + l1pwz) + lkiz_sum;
-	double a = 1.0;
-	double f0, f1, da;
+	const real C = lp - v*(ls + l1pwz) + lkiz_sum;
+	real a = 1.0;
+	real f0, f1, da;
 
 	for (size_t i=0; i<20; ++i){
 		f0 = v * digamma(v*a) - n * digamma(a) + C;
 		f1 = v*v*trigamma(v*a) - n*trigamma(a);
 		da = f0 / f1;
 		a -= da;
-		a = std::max(a, 1e-8);
-		if (std::fabs(da) <= 1e-8 * a)
+		a = std::max<real>(a, 1e-8);
+		if (abs(da) <= 1e-8 * a)
 			break;
 	}
 	return a;
 }
 
-static double log_integrand_maximum(double v, double lp, double n, double ls,
-                                    double l1pwz, double lkiz_sum)
-{
-	const double a = log_integrand_amax(v, lp, n, ls, l1pwz, lkiz_sum);
 
-	return std::lgamma(v*a) + (a-1.0) * lp - n*std::lgamma(a) - v*a*(ls + l1pwz)
-	       + (a-1) * lkiz_sum;
+template<typename real>
+struct itgmax_t {
+	real a;
+	real logI;
+};
+
+
+template<typename real>
+itgmax_t<real> log_integrand_maximum(const real v, const real lp, const real n,
+                                     const real ls, const real l1pwz,
+                                     const real lkiz_sum)
+{
+	using std::lgamma;
+	using boost::multiprecision::lgamma;
+
+	itgmax_t<real> res;
+	res.a = log_integrand_amax(v, lp, n, ls, l1pwz, lkiz_sum);
+
+	res.logI = lgamma(v*res.a) + (res.a-1.0) * lp - n*lgamma(res.a)
+	           - v*res.a*(ls + l1pwz) + (res.a-1) * lkiz_sum;
+
+	return res;
 }
 
 
 /*
  * The innermost integrand of the double integral; the integrand in `a`.
  */
-template<bool log_integrand>
-double inner_integrand_template(const double a, const double lp,
-                                const double ls, const double n,
-                                const double v, const double l1p_kiz_sum,
-                                const double l1p_wz, const double log_scale
-                                )
+template<bool log_integrand, typename real>
+real inner_integrand_template(const real a, const real lp,
+                              const real ls, const real n,
+                              const real v, const real l1p_kiz_sum,
+                              const real l1p_wz, const real log_scale
+                             )
 {
-	const double va = v * a;
+	using std::exp;
+	using boost::multiprecision::exp;
+	using std::lgamma;
+	using boost::multiprecision::lgamma;
+	using std::isinf;
+	using boost::multiprecision::isinf;
+	using std::isnan;
+	using boost::multiprecision::isnan;
+
+	auto va = v * a;
 
 	/*
 	 * Shortcut for small a
@@ -203,16 +252,16 @@ double inner_integrand_template(const double a, const double lp,
 	 */
 	if (a == 0)
 		return 0;
-	double lga = std::lgamma(a);
-	if (std::isinf(lga))
+	const real lga = lgamma(a);
+	if (isinf(lga))
 		return 0;
-	double lgva = std::lgamma(va);
-	if (std::isinf(lgva))
+	const real lgva = lgamma(va);
+	if (isinf(lgva))
 		return 0;
 
 
 	// Term PROD_i{  (1-k[i] * z) ^ (a-1)  }
-	double lS = (a-1) * l1p_kiz_sum;
+	real lS = (a-1) * l1p_kiz_sum;
 
 	// Term ( 1 / (s_new * (1-w*z))) ^ va
 	lS -= va * (ls + l1p_wz);
@@ -225,14 +274,16 @@ double inner_integrand_template(const double a, const double lp,
 		return lS;
 
 	// Compute the result and test for finiteness:
-	double result = exp(lS);
-	if (std::isinf(result)){
-		throw ScaleError("inner_integrand", lS);
+	real result = exp(lS);
+	if (isinf(result)){
+		throw ScaleError<real>("inner_integrand", lS);
 	}
 
-	if (std::isnan(result)){
+	if (isnan(result)){
 		std::string msg("inner_integrand: NaN result at a =");
-		msg.append(std::to_string(a));
+		msg.append(std::to_string(static_cast<double>(a)));
+		msg.append(". lS = ");
+		msg.append(std::to_string(static_cast<double>(lS)));
 		throw std::runtime_error(msg);
 	}
 
@@ -240,90 +291,144 @@ double inner_integrand_template(const double a, const double lp,
 }
 
 
-static double outer_integrand(double z, const double lp,
-                              const double ls, const double n,
-                              const double v, const std::vector<double>& ki,
-                              const double w, const double log_scale)
+template<typename real>
+real outer_integrand(const real z, const real lp, const real ls, const real n,
+                     const real v, const std::vector<real>& ki,
+                     const real w, const real log_scale, const real amin,
+                     const real Iref)
 {
-	/* exp_sinh tolerance: */
-	constexpr double tol = cnst_sqrt(std::numeric_limits<double>::epsilon());
+	/* Automatically choose the right numerical functions: */
+	using std::log1p;
+	using boost::multiprecision::log1p;
+	using std::exp;
+	using boost::multiprecision::exp;
+	using std::isinf;
+	using boost::multiprecision::isinf;
+	using std::isnan;
+	using boost::multiprecision::isnan;
+
+	if (isnan(z))
+		throw std::runtime_error("`z` is nan!");
 
 	// Set the inner parameters:
-	double l1p_kiz_sum = 0.0;
-	for (double k : ki)
-		l1p_kiz_sum += std::log1p(-k * z);
-	const double l1p_wz = std::log1p(-w * z);
+	real l1p_kiz_sum = 0.0;
+	for (const real& k : ki)
+		l1p_kiz_sum += log1p(-k * z);
+	const real l1p_wz = log1p(-w * z);
 
 	/* The non-degenerate case.
 	 * First compute the maximum of the a integrand at this given z:
 	 */
-	const double lImax = log_integrand_maximum(v, lp, n, ls, l1p_wz,
-	                                           l1p_kiz_sum);
+	const itgmax_t<real> lImax = log_integrand_maximum(v, lp, n, ls, l1p_wz,
+	                                                   l1p_kiz_sum);
 
 	// Integrate:
-	auto integrand = [=](double a) -> double {
-		return inner_integrand_template<false>(a, lp, ls, n, v,
-		                                       l1p_kiz_sum, l1p_wz,
-		                                       lImax);
+	auto integrand = [&](real a) -> real {
+		real result = inner_integrand_template<false>(a, lp, ls, n, v,
+		                                              l1p_kiz_sum, l1p_wz,
+		                                              lImax.logI);
+		return result;
 	};
-	double error, L1;
-	size_t levels;
-	exp_sinh<double> integrator;
-	double S = integrator.integrate(integrand, tol, &error, &L1, &levels);
 
-	if (std::isinf(S)){
-		throw ScaleError("outer_integrand", log_scale);
+	real error, L1, S;
+	try {
+		/* We wrap the integration into a try-catch to be able to distinguish
+		 * the source of the error if any should be thrown.
+		 */
+		if (lImax.a > amin){
+			size_t lvl0, lvl1;
+			real error1, L11;
+			tanh_sinh<real> int0;
+			exp_sinh<real> int1;
+			S = int0.integrate(integrand, amin, lImax.a,
+			                   TOL_TANH_SINH, &error, &L1, &lvl0)
+			  + int1.integrate(integrand, lImax.a,
+			                   std::numeric_limits<real>::infinity(),
+			                   TOL_TANH_SINH, &error1, &L11, &lvl1);
+			L1 += L1;
+			error += error1;
+		} else {
+			size_t levels;
+			tanh_sinh<real> integrator;
+			S = integrator.integrate(integrand, amin,
+			                         std::numeric_limits<real>::infinity(),
+			                         TOL_TANH_SINH, &error, &L1, &levels);
+		}
+	} catch (std::runtime_error& e){
+		std::string msg("Runtime error in outer_integrand tanh_sinh "
+		                "quadrature.\n Message: '");
+		msg += std::string(e.what());
+		msg += "'.";
+		throw std::runtime_error(msg);
+	}
+
+	if (isinf(S)){
+		throw ScaleError<real>("outer_integrand", log_scale);
 	}
 
 	/* Error checking: */
-	if (error > 1e-5 * L1){
+	constexpr double ltol = std::log(1e-5);
+	const real cmp_err = std::max<real>(log(L1),
+	                                    log(Iref) + log_scale - lImax.logI);
+	if (log(error) > ltol + cmp_err){
 		/* Check if this is relevant: */
-		throw PrecisionError("outer_integrand", error, L1);
+		throw PrecisionError<real>("outer_integrand", error, L1);
 	}
 
-	return S * exp(lImax - log_scale);
+	return S * exp(lImax.logI - log_scale);
 }
 
 
 
+template<typename real>
 struct az_t {
-	double a;
-	double z;
-	double log_integrand;
+	real a;
+	real z;
+	real log_integrand;
 };
 
 /*
  * Find the maximum of the inner integrand across all a & z
  */
-static az_t log_integrand_max(const double lp, const double ls, const double n,
-                              const double v, const double w,
-                              const std::vector<double>& ki)
+template<typename real>
+az_t<real> log_integrand_max(const real lp, const real ls, const real n,
+                             const real v, const real w, const real amin,
+                             const std::vector<real>& ki)
 {
-	/* Start from the middle of the interval: */
-	double z = 0.5;
-	double l1p_kiz_sum = 0.0;
+	using std::log1p;
+	using boost::multiprecision::log1p;
+	using std::lgamma;
+	using boost::multiprecision::lgamma;
+	using std::abs;
+	using boost::multiprecision::abs;
 
-	for (uint_fast8_t i=0; i<20; ++i){
+	/* Start from the middle of the interval: */
+	real z = 0.5;
+	real l1p_kiz_sum = 0.0;
+
+	for (uint_fast8_t i=0; i<200; ++i){
 		/* Set the new parameters:: */
 		l1p_kiz_sum = 0.0;
-		for (double k : ki)
-			l1p_kiz_sum += std::log1p(-k * z);
-		double l1p_wz = std::log1p(-w * z);
+		for (const real& k : ki)
+			l1p_kiz_sum += log1p(-k * z);
+		real l1p_wz = log1p(-w * z);
 
 		/* First and second derivatives of the above by z: */
-		double k_1mkz_sum = 0.0;
-		double k2_1mkz2_sum = 0.0;
-		for (double k : ki){
-			double x = k / (1.0 - k*z);
+		real k_1mkz_sum = 0.0;
+		real k2_1mkz2_sum = 0.0;
+		for (real k : ki){
+			real x = k / (1.0 - k*z);
 			k_1mkz_sum -= x;
 			k2_1mkz2_sum -= x*x;
 		}
-		double w_1mwz = -w / (1.0 - w*z);
-		double w2_1mwz2 = - w_1mwz * w_1mwz;
+		real w_1mwz = -w / (1.0 - w*z);
+		real w2_1mwz2 = - w_1mwz * w_1mwz;
 
 
 		/* New amax: */
-		double amax = log_integrand_amax(v, lp, n, ls, l1p_wz, l1p_kiz_sum);
+		real amax = std::max(log_integrand_amax(v, lp, n, ls, l1p_wz,
+		                                        l1p_kiz_sum),
+		                     amin);
 
 		/* Log of integrand:
 		 * f0 =   std::lgamma(v*amax) + (amax - 1.0) * lp
@@ -332,26 +437,32 @@ static az_t log_integrand_max(const double lp, const double ls, const double n,
 		 */
 
 		/* Derivative of the log of the integrand by z: */
-		double f1 = - v * amax * w_1mwz + (amax - 1.0) * k_1mkz_sum;
+		real f1 = - v * amax * w_1mwz + (amax - 1.0) * k_1mkz_sum;
 
 		/* Second derivative of the log of the integrand by z: */
-		double f2 = - v * amax * w2_1mwz2 + (amax - 1.0) * k2_1mkz2_sum;
+		real f2 = - v * amax * w2_1mwz2 + (amax - 1.0) * k2_1mkz2_sum;
 
 		/* Newton step: */
-		z = std::min(std::max(z - f1 / f2, 0.0), 1.0 - 1e-8);
+		real znext = std::min<real>(std::max<real>(z - f1 / f2, 0.0),
+		                            1.0 - 1e-8);
+		bool exit = abs(znext - z) < 1e-8;
+		z = znext;
+		if (exit)
+			break;
 	}
 
 	/* Determine amax for the final iteration: */
 	l1p_kiz_sum = 0.0;
-	for (double k : ki)
-		l1p_kiz_sum += std::log1p(-k * z);
-	double l1p_wz = std::log1p(-w * z);
-	double amax = log_integrand_amax(v, lp, n, ls, l1p_wz, l1p_kiz_sum);
+	for (const real& k : ki)
+		l1p_kiz_sum += log1p(-k * z);
+	real l1p_wz = log1p(-w * z);
+	real amax = std::max(log_integrand_amax(v, lp, n, ls, l1p_wz, l1p_kiz_sum),
+	                     amin);
 
 	/* Log of the integrand: */
-	double f0 = std::lgamma(v*amax) + (amax - 1.0) * lp
-	            - n*std::lgamma(amax) - v*amax*(ls + l1p_wz)
-	            + (amax - 1.0) * l1p_kiz_sum;
+	const real f0 = lgamma(v*amax) + (amax - 1.0) * lp
+	                - n*lgamma(amax) - v*amax*(ls + l1p_wz)
+	                + (amax - 1.0) * l1p_kiz_sum;
 
 	return {.a=amax, .z=z, .log_integrand=f0};
 }
@@ -373,159 +484,181 @@ enum C_t {
 	C0=0, C1=1, C2=2, C3=3
 };
 
-static double C1_computations(const double a, const double v, const double w,
-                              const double h0, const double h1,
-                              const unsigned char derivative=0)
+template<typename real>
+struct C1_t {
+	real deriv0;
+	real deriv1;
+	real deriv2;
+
+	C1_t(const real a, const real v, const real w, const real h0,
+	     const real h1)
+	{
+		auto h1h0 = h1 / h0;
+		deriv0 = (h1h0 + v*w/(w-1))*a - h1h0;
+		deriv1 = h1h0 + v*w/(w-1);
+		deriv2 = 0.0;
+	}
+};
+
+
+/*
+ * Constant C2:
+ */
+
+template<typename real>
+struct C2_t {
+	real deriv0;
+	real deriv1;
+	real deriv2;
+
+	C2_t(const real a, const real v, const real w, const real h0,
+	     const real h1, const real h2)
+	{
+		auto h1h0 = h1 / h0;
+		auto h2h0 = h2 / h0;
+		auto nrm = 1.0 / (w*w - 2*w + 1);
+		auto D2 = (v*v*w*w + h1h0 * (2 * v * w * (w - 1)
+		                             +  h1h0 * (1 + w * (w - 2)))
+		          ) * nrm;
+		auto D1 = (v*w*w + 2*h2h0*(w*(w - 2) + 1)
+		           - h1h0 * (2*w*v*(w - 1) + 3 * h1h0*(w*(w-2)+1))) * nrm;
+		auto D0 = 2*(h1h0*h1h0 - h2h0);
+		deriv0 = D0 + a * (D1 + a * D2);
+		deriv2 = 2 * D2;
+		deriv1 = deriv2 * a + D1;
+	}
+};
+
+
+
+/*
+ * Constant C3:
+ */
+
+template<typename real>
+struct C3_t {
+	real deriv0;
+	real deriv1;
+	real deriv2;
+
+	C3_t(const real a, const real v, const real w,
+	     const real h0, const real h1, const real h2,
+	     const real h3)
+	{
+		auto h1h0 = h1 / h0;
+		auto h2h0 = h2 / h0;
+		auto h3h0 = h3 / h0;
+		auto v2 = v*v;
+		auto v3 = v2*v;
+		auto w2 = w*w;
+		auto w3 = w2*w;
+		auto F = w * (w * (w - 3) + 3) - 1; // w3 - 3*w2 + 3*w - 1
+		auto nrm = 1/F;
+		auto D3 = (v3*w3
+		           + h1h0 * (3 * v2 * w2 * (w-1)
+		                     + h1h0 * (3 * v*w*(w*(w-2)+1)
+		                               + h1h0*F))
+		          ) * nrm;
+
+		auto D2 = 3 * (v2*w3 + 2 * h2h0 * v * w * (w-1) * (w-1)
+		               + h1h0 * (v * w2 * (v-1) * (1-w)
+		                         + 2 * h2h0 * F
+		                         + h1h0 * (3 * v * w * (w * (2-w) - 1)
+		                                   - 2 * h1h0 * F))
+		            ) * nrm;
+		auto D1 = (  2 * v * w3  +  6*h3h0 * F
+		           + 6 * h2h0 * v * w * (w * (2 - w) - 1)
+		           + h1h0 * (3 * v * w2 * (1-w)
+		                     - 18 * h2h0 * F
+		                     + h1h0 * (6 * v * w * (w2 - 2*w + 1)
+		                               + 11 * h1h0*F))
+		          ) * nrm;
+
+		auto D0 = 6 * (h1h0 * (2 * h2h0 - h1h0*h1h0) - h3h0);
+
+		deriv0 = D0 + a * (D1 + a * (D2 + a * D3));
+		deriv1 = D1 + a * (2*D2 + a * 3 * D3);
+		deriv2 = 2 * (D2 + 3 * a * D3);
+	}
+};
+
+
+template<typename real, unsigned char order>
+real large_z_amax(const real lp, const real ls, const real n,
+                  const real v, const real h0, const real h1,
+                  const real h2, const real h3, const real w,
+                  const real l1pw, const real ym, const real amin)
 {
-	const double h1h0 = h1 / h0;
-	if (derivative == 0)
-		return (h1h0 + v*w/(w-1))*a - h1h0;
-	else if (derivative == 1)
-		return h1h0 + v*w/(w-1);
+	using std::log;
+	using boost::multiprecision::log;
+	using std::abs;
+	using boost::multiprecision::abs;
 
-	return 0;
-}
-
-static double C2_computations(const double a, const double v, const double w,
-                              const double h0, const double h1, const double h2,
-                              const unsigned char derivative=0)
-{
-	const double h1h0 = h1 / h0;
-	const double h2h0 = h2 / h0;
-	const double nrm = 1.0 / (w*w - 2*w + 1);
-	const double D2 = (v*v*w*w + 2*h1h0*v*w*(w - 1) + h1h0*h1h0*w*(w - 2)
-	                   + h1h0 * h1h0) * nrm;
-	const double D1 = (v*w*w - 2*h1h0*w*v*(w - 1) + 2*h2h0*(w*(w - 2) + 1)
-	                   - 3*h1h0*h1h0*(w*(w-2)+1)) * nrm;
-	const double D0 = 2*(h1h0*h1h0 - h2h0);
-	if (derivative == 0)
-		return D2*a*a + D1 * a + D0;
-	else if (derivative == 1)
-		return 2*D2*a + D1;
-	else if (derivative == 2)
-		return 2*D2;
-	return 0.0;
-}
-
-template<unsigned char derivative>
-static double C3_computations(const double a, const double v, const double w,
-                              const double h0, const double h1, const double h2,
-                              const double h3)
-{
-	const double h1h0 = h1 / h0;
-	const double h2h0 = h2 / h0;
-	const double h3h0 = h3 / h0;
-	const double v2 = v*v;
-	const double v3 = v2*v;
-	const double w2 = w*w;
-	const double w3 = w2*w;
-	const double nrm = 1/(w3 - 3*w2 + 3*w - 1);
-	const double D3 = (v3*w3 + 3*h1h0*v2*w2*(w-1) + 3*h1h0*h1h0*v*w*(w*(w-2)+1)
-	                   + h1h0*h1h0*h1h0*(w*(w*w - 3*w + 3) - 1)) * nrm;
-
-	if (derivative == 3)
-		return 6*D3;
-
-	const double D2 = 3*(v2*w3 + h1h0*v*w2*(v-1)*(1-w) + 2*h2h0*v*w*(w-1)*(w-1)
-	                     + 3*h1h0*h1h0*v*w2*(2-w) - 3*h1h0*h1h0*v*w
-	                     + 2*h1h0*h2h0*(w*(w2 - 3*w + 3) - 1)
-	                     - 2*h1h0*h1h0*h1h0*(w*(w2 - 3*w + 3) -1)) * nrm;
-
-	if (derivative == 2)
-		return 6*D3*a + 2*D2;
-
-	const double D1 = (2*v*w3 + 3*v*w*(w*(h1h0*(1-w) + 2*h2h0*(2-w)) - 2*h2h0)
-	                   + 6*h3h0*(w3 - 3*w2 + 3*w - 1)
-	                   + 6*h1h0*h1h0*v*w*(w2 - 2*w + 1)
-	                   + 18*h1h0*h2h0*(-w3 + 3*w2 - 3*w + 1)
-	                   + 11*h1h0*h1h0*h1h0*(w3 - 3*w2 + 3*w - 1)) * nrm;
-
-	if (derivative == 1)
-		return 3*D3*a*a + 2*D2*a + D1;
-
-	const double D0 = 6*(2*h1h0*h2h0 - h3h0 - h1h0*h1h0*h1h0);
-
-	if (derivative == 0)
-		return D3*a*a*a + D2 * a*a + D1 * a + D0;
-
-	return 0.0;
-}
-
-
-template<unsigned char order>
-double large_z_amax(const double lp, const double ls, const double n,
-                    const double v, const double h0, const double h1,
-                    const double h2, const double h3, const double w,
-                    const double l1pw, const double ym)
-{
 	/* This method computes max location of the maximum of the four integrals
 	 * used in the Taylor expansion of the double integral for large z. */
 	constexpr double TOL = 1e-14;
-	const double lh0 = std::log(h0);
-	const double lym = std::log(ym);
-	double amax = (n > v) ? std::max((lp - v*ls + v*log(v) + lh0 - v * l1pw
-	                                  + lym) / (n - v), 1.0)
-	                      : 1.0;
+	const real lh0 = log(h0);
+	const real lym =  log(ym);
+	real amax = (n > v) ? std::max<real>((lp - v*ls + v*log(v) + lh0 - v * l1pw
+	                                      + lym) / (n - v), 1.0)
+	                    : 1.0;
 
 	/* Recurring terms of the first and second derivatives of the a-integrands:
 	 */
-	auto f0_base = [&](double a) -> double {
+	auto f0_base = [&](real a) -> real {
 		return v * digamma(v*a) + lp - n*digamma(a) - v*ls + lh0 - v*l1pw;
 	};
-	auto f1_base = [&](double a) -> double {
+	auto f1_base = [&](real a) -> real {
 		return v*v*trigamma(v*a) - n*trigamma(a);
 	};
 
 	if (order == 0){
-		for (int i=0; i<200; ++i){
-			const double f0 = f0_base(amax) - 1/amax + lym;
-			const double f1 = f1_base(amax) + 1/(amax*amax);
-			const double da = std::max(-f0/f1, -0.9*amax);
+		for (uint_fast8_t i=0; i<200; ++i){
+			const real f0 = f0_base(amax) - 1/amax + lym;
+			const real f1 = f1_base(amax) + 1/(amax*amax);
+			const real da = std::max<real>(-f0/f1, -0.9*amax);
 			amax += da;
-			if (std::abs(da) < TOL*std::abs(amax))
+			if (abs(da) < TOL*abs(amax))
 				break;
 		}
 	} else if (order == 1){
-		for (int i=0; i<200; ++i){
-			const double C1   = C1_computations(amax, v, w, h0, h1, 0);
-			const double C1_1 = C1_computations(amax,v,w,h0,h1,1)/C1;
-			const double C1_2 = C1_computations(amax,v,w,h0,h1,2)/C1
-			                    - C1_1*C1_1;
-			const double f0 = f0_base(amax) - 1/(amax+1) + lym + C1_1;
-			const double f1 = f1_base(amax) + 1/((amax+1)*(amax+1)) + C1_2;
-			const double da = std::max(-f0/f1, -0.9*amax);
+		for (uint_fast8_t i=0; i<200; ++i){
+			C1_t<real> C1(amax, v, w, h0, h1);
+			real C1_1 = C1.deriv1 / C1.deriv0;
+			const real f0 = f0_base(amax) - 1/(amax+1) + lym + C1_1;
+			const real f1 = f1_base(amax) + 1/((amax+1)*(amax+1))
+			                + C1.deriv2/C1.deriv0 - C1_1 * C1_1;
+			const real da = std::max<real>(-f0/f1, -0.9*amax);
 			amax += da;
-			if (std::abs(da) < TOL*std::abs(amax))
+			if (abs(da) < TOL*abs(amax))
 				break;
 		}
 	} else if (order == 2){
-		for (int i=0; i<200; ++i){
-			const double C2 = C2_computations(amax, v, w, h0, h1, h2, 0);
-			const double C2_1 = C2_computations(amax, v, w, h0, h1, h2, 1)/C2;
-			const double C2_2 = C2_computations(amax, v, w, h0, h1, h2, 2)/C2
-			                    - C2_1*C2_1;
-			const double f0 = f0_base(amax) - 1/(amax+2) + lym + C2_1;
-			const double f1 = f1_base(amax) + 1/((amax+2)*(amax+2)) + C2_2;
-			const double da = std::max(-f0/f1, -0.9*amax);
+		for (uint_fast8_t i=0; i<200; ++i){
+			C2_t<real> C2(amax, v, w, h0, h1, h2);
+			real C2_1 = C2.deriv1/C2.deriv0;
+			const real f0 = f0_base(amax) - 1/(amax+2) + lym + C2_1;
+			const real f1 = f1_base(amax) + 1/((amax+2)*(amax+2))
+			                + C2.deriv2/C2.deriv0 - C2_1 * C2_1;
+			const real da = std::max<real>(-f0/f1, -0.9*amax);
 			amax += da;
-			if (std::abs(da) < TOL*std::abs(amax))
+			if (abs(da) < TOL*abs(amax))
 				break;
 		}
 	} else if (order == 3){
 		for (int i=0; i<200; ++i){
-			const double C3 = C3_computations<0>(amax, v, w, h0, h1, h2, h3);
-			const double C3_1 = C3_computations<1>(amax,v,w,h0,h1,h2,h3)/C3;
-			const double C3_2 = C3_computations<2>(amax,v,w,h0,h1,h2,h3)/C3
-			                    - C3_1*C3_1;
-			const double f0 = f0_base(amax) - 1/(amax+3) + lym + C3_1;
-			const double f1 = f1_base(amax) + 1/((amax+3)*(amax+3)) + C3_2;
-			const double da = std::max(-f0/f1, -0.9*amax);
+			C3_t<real> C3(amax, v, w, h0, h1, h2, h3);
+			const real C3_1 = C3.deriv1/C3.deriv0;
+			auto C3_2 = C3.deriv2/C3.deriv0 - C3_1 * C3_1;
+			const real f0 = f0_base(amax) - 1/(amax+3) + lym + C3_1;
+			const real f1 = f1_base(amax) + 1/((amax+3)*(amax+3)) + C3_2;
+			const real da = std::max<real>(-f0/f1, -0.9*amax);
 			amax += da;
-			if (std::abs(da) < TOL*std::abs(amax))
+			if (abs(da) < TOL*abs(amax))
 				break;
 		}
 	}
-	return amax;
+	return std::max(amax, amin);
 }
 
 
@@ -562,66 +695,74 @@ struct params3_t {
  * Integrand of the 'a'-integral given y^(a+m)
  */
 
+template<typename real>
 struct log_double_t {
-	double log_abs;
-	short sign;
+	real log_abs;
+	int8_t sign;
 };
 
 
-template<C_t C, bool y_integrated>
-log_double_t
-a_integral_large_z_log_integrand(double a, double ly, double log_scale,
-                            const double lp, const double ls, const double n,
-                            const double v, const double w, const double h0,
-                            const double h1, const double h2, const double h3,
-                            const double l1p_w, const double lh0)
+template<C_t C, bool y_integrated, typename real>
+log_double_t<real>
+a_integral_large_z_log_integrand(real a, real ly, real log_scale,
+                                 const real lp, const real ls, const real n,
+                                 const real v, const real w, const real h0,
+                                 const real h1, const real h2, const real h3,
+                                 const real l1p_w, const real lh0)
 {
-	const double va = v * a;
+	using std::log;
+	using boost::multiprecision::log;
+	using std::lgamma;
+	using boost::multiprecision::lgamma;
+	using std::isinf;
+	using boost::multiprecision::isinf;
+
+	const real va = v * a;
 
 	// Compute C:
-	double lC = 0.0;
-	double sign = 1.0;
+	real lC = 0.0;
+	int8_t sign = 1;
 	if (C == C_t::C0){
 		/* C0 = 1 */
 		lC = 0.0;
 	} else if (C == C_t::C1) {
 		/* C1 */
-		const double C1 = C1_computations(a, v, w, h0, h1);
-		if (C1 < 0){
-			sign = -1.0;
-			lC = std::log(-C1);
+		const C1_t C1(a, v, w, h0, h1);
+		if (C1.deriv0 < 0){
+			sign = -1;
+			lC = log(-C1.deriv0);
 		} else {
-			lC = std::log(C1);
+			lC = log(C1.deriv0);
 		}
 	} else if (C == C_t::C2){
 		/* C2 */
-		const double C2 = C2_computations(a, v, w, h0, h1, h2);
-		if (C2 < 0){
-			sign = -1.0;
-			lC = std::log(-C2);
+		const C2_t C2(a, v, w, h0, h1, h2);
+		if (C2.deriv0 < 0){
+			sign = -1;
+			lC = log(-C2.deriv0);
 		} else {
-			lC = std::log(C2);
+			lC = log(C2.deriv0);
 		}
 	} else if (C == C_t::C3){
 		/* C3 */
-		const double C3 = C3_computations<0>(a, v, w, h0, h1, h2, h3);
-		if (C3 < 0){
-			sign = -1.0;
-			lC = std::log(-C3);
+		const C3_t C3(a, v, w, h0, h1, h2, h3);
+		if (C3.deriv0 < 0){
+			sign = -1;
+			lC = log(-C3.deriv0);
 		} else {
-			lC = std::log(C3);
+			lC = log(C3.deriv0);
 		}
 	}
 
 	/* Check if we might want to return -inf: */
 	if (a == 0)
-		return {.log_abs=-std::numeric_limits<double>::infinity(),
-		        .sign=(short)sign};
-	const double lgva = std::lgamma(va);
-	const double lga = std::lgamma(a);
-	if (std::isinf(lgva) || std::isinf(lga))
-		return {.log_abs=-std::numeric_limits<double>::infinity(),
-		        .sign=(short)sign};
+		return {.log_abs=-std::numeric_limits<real>::infinity(),
+		        .sign=sign};
+	const real lgva = lgamma(va);
+	const real lga = lgamma(a);
+	if (isinf(lgva) || isinf(lga))
+		return {.log_abs=-std::numeric_limits<real>::infinity(),
+		        .sign=sign};
 
 	// Term
 	//     C * y^(a+m) / (a+m)
@@ -629,128 +770,175 @@ a_integral_large_z_log_integrand(double a, double ly, double log_scale,
 	//     C * y^(a+m-1)
 	// if not integrated
 	constexpr unsigned char m = C;
-	double lS = lC;
 	if (y_integrated){
 		// Integrated:
-		lS += (a + m) * ly - std::log(a+m);
+		lC += (a + m) * ly - log(a+m);
 	} else {
 		// Not integrated:
-		lS += (a + m - 1) * ly;
+		lC += (a + m - 1) * ly;
 	}
 
 	// Term ( s_tilde / (1-w) ) ^ va
-	lS -= va * (ls + l1p_w);
+	lC -= va * (ls + l1p_w);
 
 	// Remaining summands:
-	lS += lgva + (a-1.0) * (lp + lh0) - n * lga - log_scale;
+	lC += lgva + (a-1.0) * (lp + lh0) - n * lga - log_scale;
 
-	if (std::isinf(lS)){
+	if (isinf(lC)){
 		return {.log_abs=-std::numeric_limits<double>::infinity(),
-		        .sign=(short)sign};
+		        .sign=sign};
 	}
 
-	return {.log_abs=lS, .sign=(short)sign};
+	return {.log_abs=lC, .sign=sign};
 }
 
-template<C_t C, bool y_integrated>
-double a_integral_large_z_integrand(double a, double ly, double log_scale,
-                            const double lp, const double ls, const double n,
-                            const double v, const double w, const double h0,
-                            const double h1, const double h2, const double h3,
-                            const double l1p_w, const double lh0)
+template<C_t C, bool y_integrated, typename real>
+real a_integral_large_z_integrand(real a, real ly, real log_scale,
+                                  const real lp, const real ls, const real n,
+                                  const real v, const real w, const real h0,
+                                  const real h1, const real h2, const real h3,
+                                  const real l1p_w, const real lh0)
 {
-	auto res = a_integral_large_z_log_integrand<C,y_integrated>(a, ly,
+	using std::exp;
+	using boost::multiprecision::exp;
+	using std::isinf;
+	using boost::multiprecision::isinf;
+
+	log_double_t<real> res
+	    = a_integral_large_z_log_integrand<C,y_integrated, real>(a, ly,
 	                        log_scale, lp, ls, n, v, w, h0, h1, h2, h3, l1p_w,
 	                        lh0);
 
 	// Compute the result and test for finity:
-	double result = std::exp(res.log_abs);
-	if (std::isinf(result)){
-		std::cout << "log_abs = " << res.log_abs << "\n" << std::flush;
+	real result = exp(res.log_abs);
+	if (isinf(result)){
 		if (C == C_t::C0)
-			throw ScaleError("a_integral_large_z_integrand_0", res.log_abs);
+			throw ScaleError<real>("a_integral_large_z_integrand_0",
+			                       res.log_abs);
 		else if (C == C_t::C1)
-			throw ScaleError("a_integral_large_z_integrand_1", res.log_abs);
+			throw ScaleError<real>("a_integral_large_z_integrand_1",
+			                       res.log_abs);
 		else if (C == C_t::C2)
-			throw ScaleError("a_integral_large_z_integrand_2", res.log_abs);
+			throw ScaleError<real>("a_integral_large_z_integrand_2",
+			                       res.log_abs);
 		else if (C == C_t::C3)
-			throw ScaleError("a_integral_large_z_integrand_3", res.log_abs);
+			throw ScaleError<real>("a_integral_large_z_integrand_3",
+			                       res.log_abs);
 	}
 
 	return result;
 }
 
 
-static double y_taylor_transition_root_backend(double y, const double lp,
-                            const double ls, const double n, const double v,
-                            const double h0, const double h1, const double h2,
-                            const double h3, const double lh0, const double w,
-                            const double l1p_w, const double log_scale0)
+template<typename real>
+real y_taylor_transition_root_backend(real y, const real lp, const real ls,
+                            const real n, const real v, const real h0,
+                            const real h1, const real h2, const real h3,
+                            const real lh0, const real w, const real l1p_w,
+                            const real log_scale0, const real amin)
 {
-	/* exp_sinh tolerance:
-	 * Since we only care about a rough logarithmic comparison,
-	 * we do not need very high precision in these integrals.
-	 **/
-	constexpr double tol = 1e-3;
+	using std::log;
+	using boost::multiprecision::log;
+	using std::isinf;
+	using boost::multiprecision::isinf;
+	using std::abs;
+	using boost::multiprecision::abs;
+
 	constexpr double epsilon = 1e-14;
 
 	/* Get the scale: */
-	const double amax = large_z_amax<0>(lp, ls, n, v, h0, h1, h2, h3,
-	                                    w, l1p_w, y);
-	const double ly = std::log(y);
-	const double log_scale = log_scale0
+	const real amax = large_z_amax<real,0>(lp, ls, n, v, h0, h1, h2, h3,
+	                                       w, l1p_w, y, amin);
+	const real ly = log(y);
+	const real log_scale = log_scale0
 	    + a_integral_large_z_log_integrand<C_t::C0,true>(amax, ly, log_scale0,
 	                                                lp,  ls, n, v, w, h0, h1,
 	                                                h2, h3, l1p_w,
 	                                                lh0).log_abs;
 
 	/* Compute the 'a' integrals for the constant and the cubic term: */
-	double error, L1;
+	real error, L1;
 	size_t levels;
-	exp_sinh<double> integrator;
+	exp_sinh<real> es_integrator;
+	tanh_sinh<real> ts_integrator;
 
-	auto integrand0 = [&](double a) -> double
+	auto integrand0 = [&](real a) -> real
 	{
-		return a_integral_large_z_integrand<C_t::C0,true>(a, ly, log_scale, lp,
-		                                             ls, n, v, w, h0, h1, h2,
-		                                             h3, l1p_w, lh0);
+		return a_integral_large_z_integrand<C_t::C0,true,real>(
+		                a, ly, log_scale, lp, ls, n, v, w, h0, h1,
+		                h2, h3, l1p_w, lh0
+		);
 	};
 
-	double S0 = integrator.integrate(integrand0, tol, &error, &L1, &levels);
+	real S0;
+	if (amax > amin){
+		real error1, L11;
+		S0 = ts_integrator.integrate(integrand0, amin, amax,
+		                             TOL_TANH_SINH, &error, &L1, &levels)
+		   + es_integrator.integrate(integrand0, amax,
+		                             std::numeric_limits<real>::infinity(),
+		                             TOL_TANH_SINH, &error1, &L11, &levels);
+		error += error1;
+		L1 += L11;
+	} else {
+		S0 = es_integrator.integrate(integrand0, amin,
+		                             std::numeric_limits<real>::infinity(),
+		                             TOL_TANH_SINH, &error, &L1, &levels);
+	}
 
-	if (std::isinf(S0)){
-		throw ScaleError("y_taylor_transition_root_backend_S0", log_scale);
+	if (isinf(S0)){
+		throw ScaleError<real>("y_taylor_transition_root_backend_S0",
+		                       log_scale);
 	}
 	/* Error checking: */
 	if (error > 1e-2 * L1){
-		throw PrecisionError("y_taylor_transition_root_backend_S0", error, L1);
+		throw PrecisionError<real>("y_taylor_transition_root_backend_S0",
+		                           error, L1);
 	}
 
 
-	auto integrand1 = [&](double a) -> double
+	auto integrand1 = [&](real a) -> real
 	{
-		return a_integral_large_z_integrand<C_t::C3,true>(a, ly, log_scale, lp,
-		                                             ls, n, v, w, h0, h1, h2,
-		                                             h3, l1p_w, lh0);
+		return a_integral_large_z_integrand<C_t::C3,true,real>(
+		                a, ly, log_scale, lp, ls, n, v, w, h0, h1,
+		                h2, h3, l1p_w, lh0
+		);
 	};
 
-	double S1 = integrator.integrate(integrand1, tol, &error, &L1, &levels);
 
-	if (std::isinf(S1)){
-		throw ScaleError("y_taylor_transition_root_backend_S1", log_scale);
+	real S1;
+	if (amax > amin){
+		real error1, L11;
+		S1 = ts_integrator.integrate(integrand1, amin, amax,
+		                             TOL_TANH_SINH, &error, &L1, &levels)
+		   + es_integrator.integrate(integrand1, amax,
+		                             std::numeric_limits<real>::infinity(),
+		                             TOL_TANH_SINH, &error1, &L11, &levels);
+		error += error1;
+		L1 += L11;
+	} else {
+		S1 = es_integrator.integrate(integrand1, amin,
+		                             std::numeric_limits<real>::infinity(),
+		                             TOL_TANH_SINH, &error, &L1, &levels);
+	}
+
+	if (isinf(S1)){
+		throw ScaleError<real>("y_taylor_transition_root_backend_S1",
+		                       log_scale);
 	}
 	/* Error checking: */
-	if (error > 1e-2 * std::max(L1,std::fabs(S0))){
-		throw PrecisionError("y_taylor_transition_root_backend_S1", error, L1);
+	if (error > 1e-2 * std::max<real>(L1,abs(S0))){
+		throw PrecisionError<real>("y_taylor_transition_root_backend_S1",
+		                           error, L1);
 	}
 
 	/* Extract the result: */
-	const double result = std::log(std::fabs(S1)) - std::log(epsilon)
-	                      - std::log(std::fabs(S0));
+	const real result = log(abs(S1)) - log(epsilon)
+	                    - log(abs(S0));
 
 	/* Make sure that result is finite: */
-	if (std::isinf(result)){
-		throw ScaleError("y_taylor_transition_root_backend", 300.);
+	if (isinf(result)){
+		throw ScaleError<real>("y_taylor_transition_root_backend", 300.);
 	}
 
 	return result;
@@ -759,41 +947,48 @@ static double y_taylor_transition_root_backend(double y, const double lp,
 
 
 
-static double y_taylor_transition(const double h0, const double h1,
-                 const double h2, const double h3, const double nu_new,
-                 const double lp_tilde, const double n_new,
-                 const double log_scale, const double ls_tilde,
-                 const double l1p_w, const double w,
-                 const double ymin=1e-32)
+template<typename real>
+real y_taylor_transition(const real h0, const real h1, const real h2,
+                         const real h3, const real nu_new,
+                         const real lp_tilde, const real n_new,
+                         const real log_scale, const real ls_tilde,
+                         const real l1p_w, const real w, const real amin,
+                         const real ymin = 1e-32)
 {
+	using std::log;
+	using boost::multiprecision::log;
+	using std::isnan;
+	using boost::multiprecision::isnan;
+
 	/* Find a value above the threshold: */
-	double yr = 1e-9;
-	double lh0 = std::log(h0);
-	double val = y_taylor_transition_root_backend(yr, lp_tilde, ls_tilde,
-	                                              n_new, nu_new, h0, h1, h2,
-	                                              h3, lh0, w, l1p_w,
-	                                              log_scale);
-	while (val < 0 || std::isnan(val)){
-		yr = std::min(2*yr, 1.0);
+	real yr = 1e-9;
+	real lh0 = log(h0);
+	real val = y_taylor_transition_root_backend<real>(yr, lp_tilde, ls_tilde,
+	                                                  n_new, nu_new, h0, h1, h2,
+	                                                  h3, lh0, w, l1p_w,
+	                                                  log_scale, amin);
+	while (val < 0 || isnan(val)){
+		yr = std::min<real>(2*yr, 1.0);
 		if (yr == 1.0)
 			break;
-		val = y_taylor_transition_root_backend(yr, lp_tilde, ls_tilde, n_new,
-		                                       nu_new, h0, h1, h2, h3, lh0, w,
-		                                       l1p_w, log_scale);
+		val = y_taylor_transition_root_backend<real>(yr, lp_tilde, ls_tilde,
+		                                       n_new, nu_new, h0, h1, h2, h3,
+		                                       lh0, w, l1p_w, log_scale, amin);
 	}
 
 	/* Root finding: */
-	auto rootfun = [&](double y) -> double {
-		return y_taylor_transition_root_backend(y, lp_tilde, ls_tilde, n_new,
-		                                        nu_new, h0, h1, h2, h3, lh0,
-		                                        w, l1p_w, log_scale);
+	auto rootfun = [&](real y) -> real {
+		return y_taylor_transition_root_backend<real>(y, lp_tilde, ls_tilde,
+		                                        n_new, nu_new, h0, h1, h2, h3,
+		                                        lh0, w, l1p_w, log_scale,
+		                                        amin);
 	};
 	constexpr std::uintmax_t MAX_ITER = 100;
 	std::uintmax_t max_iter = MAX_ITER;
-	eps_tolerance<double> tol(2);
+	eps_tolerance<real> tol(2);
 
-	std::pair<double,double> bracket
-	   = toms748_solve(rootfun, ymin, yr, tol, max_iter);
+	std::pair<real,real> bracket
+	   = toms748_solve(rootfun, (real)ymin, (real)yr, tol, max_iter);
 
 	if (max_iter >= MAX_ITER)
 		throw std::runtime_error("Could not determine root.");
@@ -806,105 +1001,69 @@ static double y_taylor_transition(const double h0, const double h1,
 /*
  * Compute the actual integral:
  */
-template<bool y_integrated>
-double a_integral_large_z(const double ym, const double h0, const double h1,
-                 const double h2, const double h3, const double nu_new,
-                 const double lp_tilde, const double n_new,
-                 const double log_scale, const double ls_tilde,
-                 const double l1p_w, const double w)
+template<bool y_integrated, typename real>
+real a_integral_large_z(const real ym, const real h0, const real h1,
+                        const real h2, const real h3, const real nu_new,
+                        const real lp_tilde, const real n_new,
+                        const real log_scale, const real ls_tilde,
+                        const real l1p_w, const real w, const real amin,
+                        const real S_cmp)
 {
-	/* exp_sinh tolerance: */
-	constexpr double tol = cnst_sqrt(std::numeric_limits<double>::epsilon());
+	using std::log;
+	using boost::multiprecision::log;
+	using std::isinf;
+	using boost::multiprecision::isinf;
+	using std::abs;
+	using boost::multiprecision::abs;
+	using std::isnan;
+	using boost::multiprecision::isnan;
 
 	/* Set the integrand's non-varying parameters: */
-	const double ly = std::log(ym);
-	const double lh0 = std::log(h0);
+	const real ly = log(ym);
+	const real lh0 = log(h0);
 
 	/* Integration setup for 'a' integrals:: */
-	double error, L1;
+	real error, L1, S;
 	size_t levels;
-	exp_sinh<double> integrator;
+	exp_sinh<real> integrator;
 
-	auto error_check = [&](double S, C_t C, double S_ref){
-		if (std::isinf(S)){
-			if (C == C_t::C0)
-				throw ScaleError("a_integral_large_z_S0", log_scale);
-			else if (C == C_t::C1)
-				throw ScaleError("a_integral_large_z_S1", log_scale);
-			else if (C == C_t::C2)
-				throw ScaleError("a_integral_large_z_S2", log_scale);
-			else if (C == C_t::C3)
-				throw ScaleError("a_integral_large_z_S3", log_scale);
-		}
-		/* Error checking: */
-		if (error > 1e-5 * std::max(L1,S_ref)){
-			if (C == C_t::C0)
-				throw PrecisionError("a_integral_large_z_S0", error, L1);
-			if (C == C_t::C1)
-				throw PrecisionError("a_integral_large_z_S1", error, L1);
-			if (C == C_t::C2)
-				throw PrecisionError("a_integral_large_z_S2", error, L1);
-			if (C == C_t::C3)
-				throw PrecisionError("a_integral_large_z_S3", error, L1);
-		}
-	};
-
-	/*
-	 *  Constant C0.
-	 */
-	auto integrand0 = [&](double a) -> double
+	auto integrand = [&](real a) -> real
 	{
-		return a_integral_large_z_integrand<C_t::C0, y_integrated>(a, ly,
-		                           log_scale, lp_tilde, ls_tilde, n_new, nu_new,
-		                           w, h0, h1, h2, h3, l1p_w, lh0);
-	};
-	double S_ref = 0.0;
-	double S0 = integrator.integrate(integrand0, tol, &error, &L1, &levels);
-	error_check(S0, C_t::C0, 0.0);
-	S_ref = std::fabs(S0);
-
-	/*
-	 *  Constant C1.
-	 */
-	auto integrand1 = [&](double a) -> double
-	{
-		return a_integral_large_z_integrand<C_t::C1,y_integrated>(a, ly,
-		                           log_scale, lp_tilde, ls_tilde, n_new, nu_new,
-		                           w, h0, h1, h2, h3, l1p_w, lh0);
-	};
-	double S1 = integrator.integrate(integrand1, tol, &error, &L1, &levels);
-	error_check(S1, C_t::C1, S_ref);
-	S_ref = std::max(S_ref, std::fabs(S1));
-
-	/*
-	 *  Constant C2.
-	 */
-	auto integrand2 = [&](double a) -> double
-	{
-		return a_integral_large_z_integrand<C_t::C2,y_integrated>(a, ly,
-		                           log_scale, lp_tilde, ls_tilde, n_new, nu_new,
-		                           w, h0, h1, h2, h3, l1p_w, lh0);
+		real S0 = a_integral_large_z_integrand<C_t::C0, y_integrated,real>(
+		               a, ly, log_scale, lp_tilde, ls_tilde, n_new, nu_new,
+		               w, h0, h1, h2, h3, l1p_w, lh0
+		);
+		real S1 = a_integral_large_z_integrand<C_t::C1,y_integrated,real>(
+		               a, ly,log_scale, lp_tilde, ls_tilde, n_new, nu_new,
+		               w, h0, h1, h2, h3, l1p_w, lh0
+		);
+		real S2 = a_integral_large_z_integrand<C_t::C2,y_integrated,real>(
+		               a, ly,log_scale, lp_tilde, ls_tilde, n_new, nu_new,
+		               w, h0, h1, h2, h3, l1p_w, lh0
+		);
+		real S3 = a_integral_large_z_integrand<C_t::C3,y_integrated,real>(
+		              a, ly, log_scale, lp_tilde, ls_tilde, n_new, nu_new,
+		              w, h0, h1, h2, h3, l1p_w, lh0
+		);
+		return S0 + S1 + S2 + S3;
 	};
 
-	double S2 = integrator.integrate(integrand2, tol, &error, &L1, &levels);
-	error_check(S2, C_t::C2, S_ref);
-	S_ref = std::max(S_ref, std::fabs(S2));
+	try {
+		S = integrator.integrate(integrand, amin,
+		                         std::numeric_limits<real>::infinity(),
+		                         TOL_TANH_SINH, &error, &L1, &levels);
+	} catch (std::runtime_error& e) {
+		std::string msg("Error in a_integral_large_z exp_sinh routine: '");
+		msg += e.what();
+		msg += "'.";
+		throw std::runtime_error(msg);
+	}
+	if (isinf(S) || isnan(S))
+		throw ScaleError<real>("a_integral_large_z", log_scale);
+	if (error > 1e-14 * std::max(L1, S_cmp))
+		throw PrecisionError<real>("a_integral_large_z_S3", error, L1);
 
-	/*
-	 *  Constant C3.
-	 */
-	auto integrand3 = [&](double a) -> double
-	{
-		return a_integral_large_z_integrand<C_t::C3,y_integrated>(a, ly,
-		                           log_scale, lp_tilde, ls_tilde, n_new, nu_new,
-		                           w, h0, h1, h2, h3, l1p_w, lh0);
-	};
-
-	double S3 = integrator.integrate(integrand3, tol, &error, &L1, &levels);
-	error_check(S3, C_t::C3, S_ref);
-
-
-	return S0 + S1 + S2 + S3;
+	return S;
 }
 
 
@@ -917,54 +1076,63 @@ double a_integral_large_z(const double ym, const double h0, const double h1,
 using pdtoolbox::heatflow::posterior_t;
 
 
-static void init_locals(const double* qi, const double* ci, size_t N,
-                        double nu, double n, double s, double p,
-                        // Destination parameters:
-                        double& lp_tilde, double& ls_tilde, double& nu_new,
-                        double& n_new, double& Qmax, double& h0, double& h1,
-                        double& h2, double& h3, double& w, double& l1p_w,
-                        double& ztrans, double& log_scale, double& norm,
-                        std::vector<double>& ki, double& full_taylor_integral,
-                        size_t& imax)
+template<typename real, bool need_norm=true>
+void init_locals(const double* qi, const double* ci, size_t N,
+                 const real nu, const real n, const real s, const real p,
+                 const real amin,
+                 // Destination parameters:
+                 real& lp_tilde, real& ls_tilde, real& nu_new,
+                 real& n_new, real& Qmax, real& h0, real& h1,
+                 real& h2, real& h3, real& w, real& l1p_w,
+                 real& ztrans, real& log_scale, real& norm,
+                 real& Iref, std::vector<real>& ki, real& full_taylor_integral,
+                 size_t& imax)
 {
+	using std::isinf;
+	using boost::multiprecision::isinf;
+	using std::log;
+	using boost::multiprecision::log;
+	using std::log1p;
+	using boost::multiprecision::log1p;
+
 	// Initialize parameters:
 	nu_new = nu + N;
 	n_new = n + N;
 
 	// Step 0: Determine Qmax, A, B, and ki:
 	imax = 0;
-	Qmax = std::numeric_limits<double>::infinity();
+	Qmax = std::numeric_limits<real>::infinity();
 	for (size_t i=0; i<N; ++i){
 		if (qi[i] <= 0)
 			throw std::runtime_error("At least one qi is zero or negative and "
 			                         "has hence left the model definition "
 			                         "space.");
-		double Q = qi[i] / ci[i];
+		real Q = qi[i] / ci[i];
 		if (Q > 0 && Q < Qmax){
 			Qmax = Q;
 			imax = i;
 		}
 	}
-	if (std::isinf(Qmax))
+	if (isinf(Qmax))
 		throw std::runtime_error("Found Qmax == inf. The model is not "
 		                         "well-defined. This might happen if all "
 		                         "ci <= 0, i.e. heat flow anomaly has a "
 		                         "negative or no impact on all data points.");
 
-	double A = s;
+	real A = s;
 	for (size_t i=0; i<N; ++i)
 		A += qi[i];
-	ls_tilde = std::log(A);
-	double B = 0.0;
+	ls_tilde = log(A);
+	real B = 0.0;
 	for (size_t i=0; i<N; ++i)
 		B += ci[i];
 	for (size_t i=0; i<N; ++i)
 		ki[i] = ci[i] * Qmax / qi[i];
-	double lq_sum = 0.0;
+	real lq_sum = 0.0;
 	for (size_t i=0; i<N; ++i)
-		lq_sum += std::log(qi[i]);
+		lq_sum += log(qi[i]);
 
-	lp_tilde = std::log(p) + lq_sum;
+	lp_tilde = log(p) + lq_sum;
 	w = B * Qmax / A;
 
 	// Integration config:
@@ -972,7 +1140,8 @@ static void init_locals(const double* qi, const double* ci, size_t N,
 	/* Get an estimate of the scaling: */
 
 	/* The new version: */
-	az_t azmax = log_integrand_max(lp_tilde, ls_tilde, n_new, nu_new, w, ki);
+	az_t azmax = log_integrand_max(lp_tilde, ls_tilde, n_new, nu_new, w, amin,
+	                               ki);
 	log_scale = azmax.log_integrand;
 
 	/* Compute the coefficients for the large-z (small-y) Taylor expansion: */
@@ -983,7 +1152,7 @@ static void init_locals(const double* qi, const double* ci, size_t N,
 	for (size_t i=0; i<N; ++i){
 		if (i == imax)
 			continue;
-		const double d0 = 1.0 - ki[i];
+		const real d0 = 1.0 - ki[i];
 		h3 = d0 * h3 + ki[i] * h2;
 		h2 = d0 * h2 + ki[i] * h1;
 		h1 = d0 * h1 + ki[i] * h0;
@@ -993,64 +1162,83 @@ static void init_locals(const double* qi, const double* ci, size_t N,
 	/* Step 1: Compute the normalization constant.
 	 *         This requires the full integral and might require
 	 *         a readjustment of the log_scale parameter. */
-	l1p_w = std::log1p(-w);
+	l1p_w = log1p(-w);
 	bool norm_success = false;
 	full_taylor_integral = std::nan("");
 	norm = std::nan("");
 	ztrans = std::nan("");
-	double ymax, S;
+	real ymax, S;
 
-	auto integrand = [&](double z) -> double
-	{
-		return outer_integrand(z, lp_tilde, ls_tilde, n_new, nu_new, ki, w,
-		                       log_scale);
-	};
-
-	while (!norm_success && !std::isinf(log_scale)){
+	while (!norm_success && !isinf(log_scale)){
 		// Compute the transition z where we switch to an analytic integral of
 		// the Taylor expansion:
 		try {
 			ymax = y_taylor_transition(h0, h1, h2, h3, nu_new, lp_tilde, n_new,
-			                           log_scale, ls_tilde, l1p_w, w, 1e-32);
-		} catch (ScaleError& s) {
+			                           log_scale, ls_tilde, l1p_w, w,
+			                           static_cast<real>(1e-32));
+		} catch (ScaleError<real>& s) {
 			if (s.log_scale() < 0){
 				std::string msg("Failed to determine the normalization "
 				                "constant: Encountered negative scale error "
 				                "in ");
 				msg.append(s.what());
 				msg.append(": ");
-				msg.append(std::to_string(s.log_scale()));
+				msg.append(std::to_string(static_cast<double>(s.log_scale())));
 				throw std::runtime_error(msg);
 			}
 			log_scale += s.log_scale();
 			continue;
-		} catch (PrecisionError& s){
+		} catch (PrecisionError<real>& s){
 			std::string msg("Failed to determine the normalization "
 			                "constant: Encountered precision error "
 			                "in ");
 			msg.append(s.what());
 			msg.append(": error=");
-			msg.append(std::to_string(s.error()));
+			msg.append(std::to_string(static_cast<double>(s.error())));
 			msg.append(", L1=");
-			msg.append(std::to_string(s.L1()));
+			msg.append(std::to_string(static_cast<double>(s.L1())));
 			throw std::runtime_error(msg);
 		}
 		ztrans = 1.0 - ymax;
 
-		try {
-			// 1.1: Double numerical integration in z range [0,1-ymax]:
-			double error;
-			tanh_sinh<double> integrator;
-			S = integrator.integrate(integrand, 0, ztrans, 1e-12, &error);
+		/*
+		 * For the unnormed posterior, we do not need the normalization
+		 * constant.
+		 */
+		if (!need_norm)
+			return;
 
-		} catch (ScaleError& s) {
+		try {
+			/* Compute a reference integral along the a axis at z that
+			 * corresponds to the maximum (a,z): */
+			Iref = 0;
+			Iref = outer_integrand(azmax.z, lp_tilde, ls_tilde, n_new,
+			                       nu_new, ki, w, log_scale, amin, Iref);
+
+			auto integrand = [&](real z) -> real
+			{
+				return outer_integrand(z, lp_tilde, ls_tilde, n_new, nu_new,
+				                       ki, w, log_scale, amin, Iref);
+			};
+
+			// 1.1: Double numerical integration in z range [0,1-ymax]:
+			static_assert(std::is_same<real, double>::value ||
+			              std::is_same<real, long double>::value ||
+			              std::is_same<real, float>::value ||
+			              std::is_same<real, float128>::value);
+			real error;
+			tanh_sinh<real> integrator;
+			S = integrator.integrate(integrand, static_cast<real>(0), ztrans,
+			                         TOL_TANH_SINH, &error);
+
+		} catch (ScaleError<real>& s) {
 			if (s.log_scale() < 0)
 				throw std::runtime_error("Failed to determine the "
 				                         "normalization constant: Encountered "
 				                         "negative scale error.");
 			log_scale += s.log_scale();
 			continue;
-		} catch (PrecisionError& s) {
+		} catch (PrecisionError<real>& s) {
 			s.append_message("Failed to determine the normalization "
 			                 "constant (moderate z).");
 			throw s;
@@ -1059,7 +1247,7 @@ static void init_locals(const double* qi, const double* ci, size_t N,
 			                "for the integrand: '");
 			msg.append(err.what());
 			msg.append("'.\nMore information: ztrans=");
-			msg.append(std::to_string(ztrans));
+			msg.append(std::to_string(static_cast<double>(ztrans)));
 			msg.append(", ymax=");
 			std::ostringstream os_ymax;
 			os_ymax << ymax;
@@ -1073,16 +1261,17 @@ static void init_locals(const double* qi, const double* ci, size_t N,
 			//      z in range [1-ymax, 1]:
 			full_taylor_integral =
 			a_integral_large_z<true>(ymax, h0, h1, h2, h3, nu_new, lp_tilde,
-			                   n_new, log_scale, ls_tilde, l1p_w, w);
+			                   n_new, log_scale, ls_tilde, l1p_w, w, amin,
+			                   S);
 			S += full_taylor_integral;
-		} catch (ScaleError& s) {
+		} catch (ScaleError<real>& s) {
 			if (s.log_scale() < 0)
 				throw std::runtime_error("Failed to determine the "
 				                         "normalization constant: Encountered "
 				                         "negative scale error.");
 			log_scale += s.log_scale();
 			continue;
-		} catch (PrecisionError& s) {
+		} catch (PrecisionError<real>& s) {
 			s.append_message("Failed to determine the normalization constant "
 			                 "(large z).");
 			throw s;
@@ -1091,7 +1280,7 @@ static void init_locals(const double* qi, const double* ci, size_t N,
 			                "for the integrand: '");
 			msg.append(err.what());
 			msg.append("'.\nMore information: ztrans=");
-			msg.append(std::to_string(ztrans));
+			msg.append(std::to_string(static_cast<double>(ztrans)));
 			msg.append(", ymax=");
 			std::ostringstream os_ymax;
 			os_ymax << ymax;
@@ -1114,26 +1303,47 @@ static void init_locals(const double* qi, const double* ci, size_t N,
 template<posterior_t type>
 void posterior(const double* x, double* res, size_t Nx, const double* qi,
                const double* ci, size_t N, double p, double s, double n,
-               double nu, double dest_tol)
+               double nu, double amin, double dest_tol)
 {
+	using std::log;
+	using boost::multiprecision::log;
+	using std::abs;
+	using boost::multiprecision::abs;
+	using std::isnan;
+	using boost::multiprecision::isnan;
+
 	/* Computes the posterior for a given parameter combination using
 	 * two-dimensional adaptive quadrature.
 	 */
 
+	//typedef long double real;
+	//typedef boost::multiprecision::cpp_dec_float_100 real;
+	typedef real_t real;
+
+	typedef gauss_kronrod<real, 15> GK;
+
+
 	/* Step 1: Use the common parameter initialization routine which
 	 *         mainly determines the normalization constant: */
-	double lp_tilde=0, ls_tilde=0, nu_new=0, n_new=0, Qmax=0, h0=0, h1=0,
-	       h2=0, h3=0, w=0, l1p_w=0, ztrans=0, log_scale=0, norm=0,
-	       full_taylor_integral=0;
+	real lp_tilde=0, ls_tilde=0, nu_new=0, n_new=0, Qmax=0, h0=0, h1=0,
+	     h2=0, h3=0, w=0, l1p_w=0, ztrans=0, log_scale=0, norm=0,
+	     full_taylor_integral=0, Iref=0;
 	size_t imax;
-	std::vector<double> ki(N);
-	init_locals(qi, ci, N, nu, n, s, p, lp_tilde,
-	            ls_tilde, nu_new, n_new, Qmax, h0, h1, h2, h3, w, l1p_w,
-	            ztrans, log_scale, norm, ki, full_taylor_integral, imax);
+	std::vector<real> ki(N);
+	if (type == posterior_t::UNNORMED_LOG)
+		init_locals<real,false>(qi, ci, N, (real)nu, (real)n, (real)s, (real)p,
+		            (real)amin, lp_tilde, ls_tilde, nu_new, n_new, Qmax, h0, h1,
+		            h2, h3, w, l1p_w, ztrans, log_scale, norm, Iref, ki,
+		            full_taylor_integral, imax);
+	else
+		init_locals(qi, ci, N, (real)nu, (real)n, (real)s, (real)p, (real)amin,
+		            lp_tilde, ls_tilde, nu_new, n_new, Qmax, h0, h1, h2, h3, w,
+		            l1p_w, ztrans, log_scale, norm, Iref, ki,
+		            full_taylor_integral, imax);
 
 	std::vector<size_t> order(0);
 	bool is_cumulative = type & (posterior_t::CUMULATIVE | posterior_t::TAIL);
-	double z_last = 0.0, S_cumul = 0.0;
+	real z_last = 0.0, S_cumul = 0.0;
 	if (is_cumulative){
 		order.resize(Nx);
 		for (size_t i=0; i<Nx; ++i){
@@ -1160,15 +1370,17 @@ void posterior(const double* x, double* res, size_t Nx, const double* qi,
 		}
 	}
 
-	auto integrand = [&](double z) -> double {
-		return outer_integrand(z, lp_tilde, ls_tilde, n_new, nu_new, ki, w,
-		                       log_scale);
+	auto integrand = [&](real z) -> real {
+		return outer_integrand<real>(z, lp_tilde, ls_tilde, n_new, nu_new, ki,
+		                             w, log_scale, amin, Iref);
 	};
 
 	/* A condition for deciding the integrator: */
-	bool use_thsh = (integrand(ztrans)*ztrans > 2*norm);
+	bool use_thsh = false;
+	if (type == posterior_t::TAIL || type == posterior_t::CUMULATIVE)
+		use_thsh = (integrand(ztrans)*ztrans > 2*norm);
 
-	tanh_sinh<double> thsh_int;
+	tanh_sinh<real> thsh_int;
 	// /* Step 2: Compute the values: */
 	for (size_t i=0; i<Nx; ++i){
 		const size_t j = (is_cumulative) ? order[i] : i;
@@ -1192,7 +1404,12 @@ void posterior(const double* x, double* res, size_t Nx, const double* qi,
 		}
 
 		/* Continue depending on chosen representation of the posterior: */
-		const double zi = x[j] / Qmax;
+		const real zi = x[j] / Qmax;
+		if (isnan(zi)){
+			res[j] = std::nan("");
+			continue;
+		}
+
 		if (type == posterior_t::DENSITY){
 			/* Return the density in P_H (aka \dot{Q}) of the posterior.
 			 * To do so, return the outer integrand at z corresponding to the
@@ -1201,24 +1418,26 @@ void posterior(const double* x, double* res, size_t Nx, const double* qi,
 			 * variables x->z by dividing the PDF by Qmax.
 			 */
 			if (zi <= ztrans)
-				res[j] = integrand(zi) / (Qmax * norm);
+				res[j] = static_cast<double>(integrand(zi) / (Qmax * norm));
 			else
 				// Use the Taylor expansion for the limit z->1, y=1-z -> 0:
-				res[j] = a_integral_large_z<false>(1.0-zi, h0, h1, h2, h3,
-				                       nu_new, lp_tilde, n_new, log_scale,
-				                       ls_tilde, l1p_w, w)
-				         / (Qmax * norm);
+				res[j] = static_cast<double>(
+				             a_integral_large_z<false,real>(1.0-zi, h0, h1, h2,
+				                       h3, nu_new, lp_tilde, n_new, log_scale,
+				                       ls_tilde, l1p_w, w, amin, norm)
+				         / (Qmax * norm)
+				);
 		} else if (type == posterior_t::CUMULATIVE){
-			double S;
+			real S;
 			if (zi <= ztrans){
-				double err;
-				constexpr double eps_tol
+				real err;
+				const real eps_tol
 				   = boost::math::tools::root_epsilon<double>();
 				if (z_last == zi){
 					S = 0;
 				} else {
 					S = GK::integrate(integrand, z_last, zi, 1,
-						              eps_tol, &err);
+					                  eps_tol, &err);
 					if (err > 1e-2 * dest_tol * norm) {
 						if (S != 0)
 							S = GK::integrate(integrand, z_last, zi, 15,
@@ -1235,14 +1454,15 @@ void posterior(const double* x, double* res, size_t Nx, const double* qi,
 				if (i+1 == Nx){
 					S = GK::integrate(integrand, z_last,
 					                                ztrans);
-					double norm_num = S + S_cumul + full_taylor_integral;
-					if (std::fabs(norm_num - norm) > dest_tol * norm){
-						throw PrecisionError("CDF normalization failed to "
-						                     "achieve the desired precision.",
-						                     std::fabs(norm_num - norm), norm);
+					real norm_num = S + S_cumul + full_taylor_integral;
+					if (abs(norm_num - norm) > dest_tol * norm){
+						throw PrecisionError<real>("CDF normalization failed "
+						                     "to achieve the desired "
+						                     "precision.",
+						                     abs(norm_num - norm), norm);
 					}
 					/* Renormalize: */
-					const double rescale = 1.0 / norm_num;
+					const double rescale = 1.0 / static_cast<double>(norm_num);
 					for (size_t k=0; k<Nx; ++k)
 						res[k] *= rescale;
 				}
@@ -1250,24 +1470,28 @@ void posterior(const double* x, double* res, size_t Nx, const double* qi,
 				/* Sanity check: */
 				if (z_last < ztrans){
 					S = GK::integrate(integrand, z_last, ztrans);
-					double norm_num = S + S_cumul + full_taylor_integral;
-					if (std::fabs(norm_num - norm) > dest_tol * norm){
-						throw PrecisionError("CDF normalization failed to "
-						                     "achieve the desired precision.",
-						                     std::fabs(norm_num - norm), norm);
+					real norm_num = S + S_cumul + full_taylor_integral;
+					if (abs(norm_num - norm) > dest_tol * norm){
+						throw PrecisionError<real>("CDF normalization failed "
+						                           "to achieve the desired "
+						                           "precision.",
+						                           abs(norm_num - norm),
+						                           norm);
 					}
 				}
 				/* Now integrate from the back: */
 				S = norm
-				    - a_integral_large_z<true>(1.0-zi, h0, h1, h2, h3, nu_new,
-				                       lp_tilde, n_new, log_scale, ls_tilde,
-				                       l1p_w, w);
+				    - a_integral_large_z<true, real>(1.0-zi, h0, h1, h2, h3,
+				                       nu_new, lp_tilde, n_new, log_scale,
+				                       ls_tilde, l1p_w, w, amin, norm);
 				S_cumul += S;
 				z_last = zi;
 			}
-			res[j] = std::max(std::min(S_cumul / norm, 1.0), 0.0);
+			res[j] = static_cast<double>(
+			    std::max<real>(std::min<real>(S_cumul / norm, 1.0), 0.0)
+			);
 		} else if (type == posterior_t::TAIL){
-			double S;
+			real S;
 			if (zi <= ztrans){
 				// First the part from zi to ztrans:
 				if (z_last >= ztrans){
@@ -1277,14 +1501,14 @@ void posterior(const double* x, double* res, size_t Nx, const double* qi,
 				if (use_thsh)
 					S = thsh_int.integrate(integrand, zi, z_last);
 				else {
-					double err;
+					real err;
 					constexpr double eps_tol
 					   = boost::math::tools::root_epsilon<double>();
 					if (zi == z_last){
 						S = 0.0;
 					} else {
 						S = GK::integrate(integrand, zi, z_last, 1,
-						                  eps_tol, &err);
+						                  (real)eps_tol, &err);
 						if (err > 1e-2 * dest_tol * norm) {
 							if (S != 0)
 								S = GK::integrate(integrand, zi, z_last,
@@ -1300,12 +1524,14 @@ void posterior(const double* x, double* res, size_t Nx, const double* qi,
 				z_last = zi;
 			} else {
 				// The part from zi to 1:
-				S_cumul = a_integral_large_z<true>(1.0-zi, h0, h1, h2, h3,
-				                       nu_new, lp_tilde, n_new, log_scale,
-				                       ls_tilde, l1p_w, w);
+				S_cumul = a_integral_large_z<true, real>(1.0-zi, h0, h1, h2,
+				                       h3, nu_new, lp_tilde, n_new, log_scale,
+				                       ls_tilde, l1p_w, w, amin, norm);
 				z_last = zi;
 			}
-			res[j] = std::max(std::min(S_cumul / norm, 1.0), 0.0);
+			res[j] = static_cast<double>(
+			    std::max<real>(std::min<real>(S_cumul / norm, 1.0), 0.0)
+			);
 
 			/* Sanity check of the normalization: */
 			if (i+1 == Nx && z_last < ztrans){
@@ -1316,15 +1542,17 @@ void posterior(const double* x, double* res, size_t Nx, const double* qi,
 						S = GK::integrate(integrand, 0, z_last);
 				else
 					S = 0.0;
-				double norm_num = S + S_cumul;
-				if (std::fabs(norm_num - norm) > dest_tol * norm){
-					throw PrecisionError("Tail distribution normalization "
-					                     "failed to achieve the desired "
-					                     "precision.",
-					                     std::fabs(norm_num - norm), norm);
+				real norm_num = S + S_cumul;
+				if (abs(norm_num - norm) > dest_tol * norm){
+					throw PrecisionError<real>("Tail distribution "
+					                           "normalization failed to "
+					                           "achieve the desired "
+					                           "precision.",
+					                          abs(norm_num - norm),
+					                           norm);
 				}
 				/* Renormalize: */
-				const double rescale = norm / norm_num;
+				const double rescale = static_cast<double>(norm / norm_num);
 				for (size_t k=0; k<Nx; ++k)
 					res[k] *= rescale;
 			}
@@ -1336,12 +1564,14 @@ void posterior(const double* x, double* res, size_t Nx, const double* qi,
 			 * when normalizing.
 			 */
 			if (zi <= ztrans){
-				res[j] = std::log(integrand(zi)) + log_scale;
+				res[j] = static_cast<double>(log(integrand(zi)) + log_scale);
 			} else {
-				res[j] = std::log(a_integral_large_z<false>(1.0-zi, h0, h1, h2,
-				                       h3, nu_new, lp_tilde, n_new, log_scale,
-				                       ls_tilde, l1p_w, w))
-				         + log_scale;
+				res[j] = static_cast<double>(
+				    log(a_integral_large_z<false,real>(1.0-zi, h0, h1,
+				             h2, h3, nu_new, lp_tilde, n_new, log_scale,
+				             ls_tilde, l1p_w, w, amin, 0.0))
+				         + log_scale
+				);
 			}
 		}
 	}
@@ -1356,9 +1586,9 @@ namespace heatflow {
 
 void posterior_pdf(const double* x, double* res, size_t Nx, const double* qi,
                    const double* ci, size_t N, double p, double s, double n,
-                   double nu, double dest_tol)
+                   double nu, double amin, double dest_tol)
 {
-	posterior<DENSITY>(x, res, Nx, qi, ci, N, p, s, n, nu, dest_tol);
+	posterior<DENSITY>(x, res, Nx, qi, ci, N, p, s, n, nu, amin, dest_tol);
 }
 
 
@@ -1367,7 +1597,7 @@ void posterior_pdf_batch(const double* x, size_t Nx, double* res,
                          const std::vector<const double*>& ci,
                          const std::vector<size_t>& N,
                          double p, double s, double n, double nu,
-                         double dest_tol)
+                         double amin, double dest_tol)
 {
 	/* Sanity: */
 	if (qi.size() != ci.size())
@@ -1380,12 +1610,14 @@ void posterior_pdf_batch(const double* x, size_t Nx, double* res,
 
 	#pragma omp parallel for
 	for (size_t i=0; i<qi.size(); ++i){
-		try {
-			posterior_pdf(x, res + Nx*i, Nx, qi[i], ci[i], N[i], p, s, n, nu,
-			              dest_tol);
-		} catch (const std::exception& e){
-			error_flag = true;
-			err_msg = std::string(e.what());
+		if (!error_flag){
+			try {
+				posterior_pdf(x, res + Nx*i, Nx, qi[i], ci[i], N[i], p, s, n,
+				              nu, amin, dest_tol);
+			} catch (const std::exception& e){
+				error_flag = true;
+				err_msg = std::string(e.what());
+			}
 		}
 	}
 
@@ -1399,9 +1631,9 @@ void posterior_pdf_batch(const double* x, size_t Nx, double* res,
 
 void posterior_cdf(const double* x, double* res, size_t Nx, const double* qi,
                    const double* ci, size_t N, double p, double s, double n,
-                   double nu, double dest_tol)
+                   double nu, double amin, double dest_tol)
 {
-	posterior<CUMULATIVE>(x, res, Nx, qi, ci, N, p, s, n, nu, dest_tol);
+	posterior<CUMULATIVE>(x, res, Nx, qi, ci, N, p, s, n, nu, amin, dest_tol);
 }
 
 
@@ -1410,7 +1642,7 @@ void posterior_cdf_batch(const double* x, size_t Nx, double* res,
                          const std::vector<const double*>& ci,
                          const std::vector<size_t>& N,
                          double p, double s, double n, double nu,
-                         double dest_tol)
+                         double amin, double dest_tol)
 {
 	/* Sanity: */
 	if (qi.size() != ci.size())
@@ -1423,12 +1655,14 @@ void posterior_cdf_batch(const double* x, size_t Nx, double* res,
 
 	#pragma omp parallel for
 	for (size_t i=0; i<qi.size(); ++i){
-		try {
-			posterior_cdf(x, res + Nx*i, Nx, qi[i], ci[i], N[i], p, s, n, nu,
-			              dest_tol);
-		} catch (const std::exception& e){
-			error_flag = true;
-			err_msg = std::string(e.what());
+		if (!error_flag){
+			try {
+				posterior_cdf(x, res + Nx*i, Nx, qi[i], ci[i], N[i], p, s, n,
+				              nu, amin, dest_tol);
+			} catch (const std::exception& e){
+				error_flag = true;
+				err_msg = std::string(e.what());
+			}
 		}
 	}
 
@@ -1442,9 +1676,9 @@ void posterior_cdf_batch(const double* x, size_t Nx, double* res,
 
 void posterior_tail(const double* x, double* res, size_t Nx, const double* qi,
                     const double* ci, size_t N, double p, double s, double n,
-                    double nu, double dest_tol)
+                    double nu, double amin, double dest_tol)
 {
-	posterior<TAIL>(x, res, Nx, qi, ci, N, p, s, n, nu, dest_tol);
+	posterior<TAIL>(x, res, Nx, qi, ci, N, p, s, n, nu, amin, dest_tol);
 }
 
 
@@ -1453,7 +1687,7 @@ void posterior_tail_batch(const double* x, size_t Nx, double* res,
                           const std::vector<const double*>& ci,
                           const std::vector<size_t>& N,
                           double p, double s, double n, double nu,
-                          double dest_tol)
+                          double amin, double dest_tol)
 {
 	/* Sanity: */
 	if (qi.size() != ci.size())
@@ -1466,12 +1700,14 @@ void posterior_tail_batch(const double* x, size_t Nx, double* res,
 
 	#pragma omp parallel for
 	for (size_t i=0; i<qi.size(); ++i){
-		try {
-			posterior_tail(x, res + Nx*i, Nx, qi[i], ci[i], N[i], p, s, n, nu,
-			               dest_tol);
-		} catch (const std::exception& e){
-			error_flag = true;
-			err_msg = std::string(e.what());
+		if (!error_flag){
+			try {
+				posterior_tail(x, res + Nx*i, Nx, qi[i], ci[i], N[i], p, s, n,
+				               nu, amin, dest_tol);
+			} catch (const std::exception& e){
+				error_flag = true;
+				err_msg = std::string(e.what());
+			}
 		}
 	}
 
@@ -1486,9 +1722,10 @@ void posterior_tail_batch(const double* x, size_t Nx, double* res,
 void posterior_log_unnormed(const double* x, double* res, size_t Nx,
                             const double* qi, const double* ci, size_t N,
                             double p, double s, double n, double nu,
-                            double dest_tol)
+                            double amin, double dest_tol)
 {
-	posterior<UNNORMED_LOG>(x, res, Nx, qi, ci, N, p, s, n, nu, dest_tol);
+	posterior<UNNORMED_LOG>(x, res, Nx, qi, ci, N, p, s, n, nu,
+	                        amin, dest_tol);
 }
 
 
@@ -1497,19 +1734,21 @@ void posterior_log_unnormed(const double* x, double* res, size_t Nx,
  */
 void posterior_silent(const double* x, double* res, size_t Nx, const double* qi,
                const double* ci, size_t N, double p, double s, double n,
-               double nu, double dest_tol, posterior_t type)
+               double nu, double amin, double dest_tol, posterior_t type)
 {
 	try {
 		if (type == DENSITY)
-			posterior<DENSITY>(x, res, Nx, qi, ci, N, p, s, n, nu, dest_tol);
+			posterior<DENSITY>(x, res, Nx, qi, ci, N, p, s, n, nu, amin,
+			                   dest_tol);
 		else if (type == CUMULATIVE)
 			posterior<CUMULATIVE>(x, res, Nx, qi, ci, N, p, s, n, nu,
-			                      dest_tol);
+			                      amin, dest_tol);
 		else if (type == TAIL)
-			posterior<TAIL>(x, res, Nx, qi, ci, N, p, s, n, nu, dest_tol);
+			posterior<TAIL>(x, res, Nx, qi, ci, N, p, s, n, nu, amin,
+			                dest_tol);
 		else if (type == UNNORMED_LOG)
 			posterior<UNNORMED_LOG>(x, res, Nx, qi, ci, N, p, s, n, nu,
-			                        dest_tol);
+			                        amin, dest_tol);
 	} catch (std::runtime_error& e) {
 		for (size_t i=0; i<Nx; ++i){
 			res[i] = std::numeric_limits<double>::quiet_NaN();
@@ -1525,7 +1764,7 @@ void posterior_silent(const double* x, double* res, size_t Nx, const double* qi,
 void tail_quantiles(const double* quantiles, double* res, const size_t Nquant,
                     const double* qi, const double* ci, const size_t N,
                     const double p, const double s, const double n,
-                    const double nu, const double dest_tol)
+                    const double nu, const double amin, const double dest_tol)
 {
 	/* Estimates the tail quantiles using the QuantileInverter class. */
 
@@ -1533,24 +1772,24 @@ void tail_quantiles(const double* quantiles, double* res, const size_t Nquant,
 	 *         mainly determines the normalization constant: */
 	double lp_tilde=0, ls_tilde=0, nu_new=0, n_new=0, Qmax=0, h0=0, h1=0,
 	       h2=0, h3=0, w=0, l1p_w=0, ztrans=0, log_scale=0, norm=0,
-	       full_taylor_integral=0;
+	       full_taylor_integral=0, Iref=0;
 	size_t imax;
 	std::vector<double> ki(N);
-	init_locals(qi, ci, N, nu, n, s, p, lp_tilde,
+	init_locals(qi, ci, N, nu, n, s, p, amin, lp_tilde,
 	            ls_tilde, nu_new, n_new, Qmax, h0, h1, h2, h3, w, l1p_w,
-	            ztrans, log_scale, norm, ki, full_taylor_integral, imax);
+	            ztrans, log_scale, norm, Iref, ki, full_taylor_integral, imax);
 
 
 	auto integrand = [&](double z) -> double {
 		double result = 0.0;
 		if (z <= ztrans)
 			result = outer_integrand(z, lp_tilde, ls_tilde, n_new, nu_new,
-			                         ki, w, log_scale) / norm;
+			                         ki, w, log_scale, amin, Iref) / norm;
 		else if (z < 1)
 			result = a_integral_large_z<false>(1.0-z, h0, h1, h2, h3,
 			                                   nu_new, lp_tilde, n_new,
 			                                   log_scale, ls_tilde,
-			                                   l1p_w, w) / norm;
+			                                   l1p_w, w, amin, norm) / norm;
 
 		return result;
 	};
@@ -1590,7 +1829,7 @@ void posterior_tail_quantiles_batch(
                      const std::vector<const double*>& ci,
                      const std::vector<size_t>& N,
                      double p, double s, double n, double nu,
-                     double dest_tol)
+                     double amin, double dest_tol)
 {
 	/* Sanity: */
 	if (qi.size() != ci.size())
@@ -1622,25 +1861,30 @@ void posterior_tail_quantiles_batch(
 		double ztrans;
 		double log_scale;
 		double norm;
+		double Iref;
 		double full_taylor_integral;
 		std::vector<double> ki;
 	};
 	std::vector<locals_t> locals(qi.size());
 	#pragma omp parallel for
 	for (size_t i=0; i<qi.size(); ++i){
-		size_t imax;
-		try {
-			locals[i].ki.resize(N[i]);
-			init_locals(qi[i], ci[i], N[i], nu, n, s, p, locals[i].lp_tilde,
-			            locals[i].ls_tilde, locals[i].nu_new, locals[i].n_new,
-			            locals[i].Qmax, locals[i].h0, locals[i].h1,
-			            locals[i].h2, locals[i].h3, locals[i].w,
-			            locals[i].l1p_w, locals[i].ztrans, locals[i].log_scale,
-			            locals[i].norm, locals[i].ki,
-			            locals[i].full_taylor_integral, imax);
-		} catch (const std::exception& e){
-			error_flag = true;
-			err_msg = std::string(e.what());
+		if (!error_flag){
+			size_t imax;
+			try {
+				locals[i].ki.resize(N[i]);
+				init_locals(qi[i], ci[i], N[i], nu, n, s, p, amin,
+				            locals[i].lp_tilde, locals[i].ls_tilde,
+				            locals[i].nu_new, locals[i].n_new,
+				            locals[i].Qmax, locals[i].h0, locals[i].h1,
+				            locals[i].h2, locals[i].h3, locals[i].w,
+				            locals[i].l1p_w, locals[i].ztrans,
+				            locals[i].log_scale, locals[i].norm,
+				            locals[i].Iref, locals[i].ki,
+				            locals[i].full_taylor_integral, imax);
+			} catch (const std::exception& e){
+				error_flag = true;
+				err_msg = std::string(e.what());
+			}
 		}
 	}
 
@@ -1672,7 +1916,8 @@ void posterior_tail_quantiles_batch(
 				result += outer_integrand(z, locals[i].lp_tilde,
 				                          locals[i].ls_tilde, locals[i].n_new,
 				                          locals[i].nu_new, locals[i].ki,
-				                          locals[i].w, locals[i].log_scale)
+				                          locals[i].w, locals[i].log_scale,
+				                          amin, locals[i].Iref)
 				          / locals[i].norm;
 			else if (z < 1)
 				result += a_integral_large_z<false>(1.0-z, locals[i].h0,
@@ -1681,7 +1926,8 @@ void posterior_tail_quantiles_batch(
 				                           locals[i].lp_tilde, locals[i].n_new,
 				                           locals[i].log_scale,
 				                           locals[i].ls_tilde, locals[i].l1p_w,
-				                           locals[i].w) / locals[i].norm;
+				                           locals[i].w, amin,
+				                           locals[i].norm) / locals[i].norm;
 		}
 
 		return result / qi.size();
@@ -1729,19 +1975,19 @@ int tail_quantiles_intcode(const double* quantiles, double* res,
                            const size_t Nquant, const double* qi,
                            const double* ci, const size_t N, const double p,
                            const double s, const double n, const double nu,
-                           const double dest_tol,
+                           const double amin, const double dest_tol,
                            short print)
 {
 	try {
 		tail_quantiles(quantiles, res, Nquant, qi, ci, N, p, s, n, nu,
-		               dest_tol);
-	}  catch (ScaleError& e){
+		               amin, dest_tol);
+	}  catch (ScaleError<double>& e){
 		if (print){
 			std::cerr << "ScaleError (" << e.what() << "\n"
 			             "log_scale: " << e.log_scale() << "\n";
 		}
 		return 1;
-	} catch (PrecisionError& pe) {
+	} catch (PrecisionError<double>& pe) {
 		if (print){
 			std::cerr << "A precision error happened.\n" << pe.what() << "\n";
 		}

--- a/external/pdtoolbox/src/ziebarth2022a.cpp
+++ b/external/pdtoolbox/src/ziebarth2022a.cpp
@@ -83,11 +83,6 @@ using boost::multiprecision::cpp_dec_float_100;
 #endif
 
 
-/* tanh_sinh tolerance: */
-constexpr double TOL_TANH_SINH
-     = cnst_sqrt(std::numeric_limits<double>::epsilon());
-
-
 /* A custom exception type indicating that the integral is out of
  * scale for double precision: */
 template<typename real>
@@ -335,6 +330,8 @@ real outer_integrand(const real z, const locals_t<real>& L)
 	using boost::multiprecision::isinf;
 	using std::isnan;
 	using boost::multiprecision::isnan;
+
+	const real TOL_TANH_SINH = boost::math::tools::root_epsilon<real>();
 
 	if (isnan(z))
 		throw std::runtime_error("`z` is nan!");
@@ -827,6 +824,8 @@ real y_taylor_transition_root_backend(real y, const locals_t<real>& L)
 
 	constexpr double epsilon = 1e-14;
 
+	const real TOL_TANH_SINH = boost::math::tools::root_epsilon<real>();
+
 	/* Get the scale: */
 	const real amax = large_z_amax<real,0>(y, L);
 	const real ly = log(y);
@@ -976,6 +975,8 @@ real a_integral_large_z(const real ym, const real S_cmp,
 	using std::isnan;
 	using boost::multiprecision::isnan;
 
+	const real TOL_TANH_SINH = boost::math::tools::root_epsilon<real>();
+
 	/* Set the integrand's non-varying parameters: */
 	const real ly = log(ym);
 	const real lScmp = log(S_cmp);
@@ -1043,6 +1044,8 @@ void init_locals(const double* qi, const double* ci, size_t N,
 	using boost::multiprecision::log;
 	using std::log1p;
 	using boost::multiprecision::log1p;
+
+	const real TOL_TANH_SINH = boost::math::tools::root_epsilon<real>();
 
 	// Initialize parameters:
 	L.v = v + N;

--- a/external/pdtoolbox/src/ziebarth2022a.cpp
+++ b/external/pdtoolbox/src/ziebarth2022a.cpp
@@ -372,7 +372,7 @@ real outer_integrand(const real z, const locals_t<real>& L)
 			  + int1.integrate(integrand, lImax.a,
 			                   std::numeric_limits<real>::infinity(),
 			                   TOL_TANH_SINH, &error1, &L11, &lvl1);
-			L1 += L1;
+			L1 += L11;
 			error += error1;
 		} else {
 			size_t levels;

--- a/external/zeal2022hfpc/include/resilience.hpp
+++ b/external/zeal2022hfpc/include/resilience.hpp
@@ -45,7 +45,7 @@ struct quantiles_t {
 std::vector<quantiles_t>
 test_performance_1q(size_t N, size_t M, double P_MW, double K, double T,
                     double quantile, double PRIOR_P, double PRIOR_S,
-                    double PRIOR_N, double PRIOR_V, bool verbose,
+                    double PRIOR_N, double PRIOR_V, double amin, bool verbose,
                     bool show_failures, size_t seed,
                     unsigned short nthread, double tolerance);
 
@@ -53,7 +53,7 @@ std::vector<quantiles_t>
 test_performance_41q(size_t N, size_t M, double P_MW, double K, double T,
                      const std::array<double,41>& quantile, double PRIOR_P,
                      double PRIOR_S, double PRIOR_N, double PRIOR_V,
-                     bool verbose, bool show_failures, size_t seed,
+                     double amin, bool verbose, bool show_failures, size_t seed,
                      unsigned short nthread, double tolerance);
 
 std::vector<quantiles_t>
@@ -61,16 +61,18 @@ test_performance_mixture_4q(size_t N, size_t M, double P_MW, double x0,
                     double s0, double a0, double x1, double s1, double a1,
                     const std::array<double,4>& quantiles,
                     double PRIOR_P, double PRIOR_S, double PRIOR_N,
-                    double PRIOR_V, bool verbose, bool show_failures,
-                    size_t seed, unsigned short nthread, double tolerance);
+                    double PRIOR_V, double amin, bool verbose,
+                    bool show_failures, size_t seed, unsigned short nthread,
+                    double tolerance);
 
 std::vector<quantiles_t>
 test_performance_mixture_41q(size_t N, size_t M, double P_MW, double x0,
                     double s0, double a0, double x1, double s1, double a1,
                     const std::array<double,41>& quantiles,
                     double PRIOR_P, double PRIOR_S, double PRIOR_N,
-                    double PRIOR_V, bool verbose, bool show_failures,
-                    size_t seed, unsigned short nthread, double tolerance);
+                    double PRIOR_V, double amin, bool verbose,
+                    bool show_failures, size_t seed, unsigned short nthread,
+                    double tolerance);
 
 
 }

--- a/include/numerics/cdfeval.hpp
+++ b/include/numerics/cdfeval.hpp
@@ -1,0 +1,317 @@
+/*
+ * A class to evaluate cumulative distribution functions from unnormed
+ * densities.
+ *
+ * Author: Malte J. Ziebarth (ziebarth@gfz-potsdam.de)
+ *
+ * Copyright (C) 2022 Malte J. Ziebarth
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef REHEATFUNQ_NUMERICS_CDFEVAL_HPP
+#define REHEATFUNQ_NUMERICS_CDFEVAL_HPP
+
+#include <vector>
+#include <iostream>
+#include <boost/math/quadrature/gauss_kronrod.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/multiprecision/float128.hpp>
+
+
+namespace reheatfunq {
+
+template<typename real>
+class CDFEval {
+public:
+	template<typename func>
+	CDFEval(const std::vector<real>& x, func F,
+	        const real xmin, const real xmax,
+	        const real outside_mass = 0.0,
+	        const real dest_tol = 1e-8);
+
+	real cdf(const real& x) const;
+
+	real tail(const real& x) const;
+
+	void add_outside_mass(const real mass, bool above=true);
+
+	real norm() const {
+		return _norm;
+	};
+
+private:
+	struct xy_t {
+		real x;
+		real cdf;
+		real tail;
+
+		bool operator<(const xy_t& other) {
+			return x < other.x;
+		};
+	};
+	std::vector<xy_t> intervals;
+
+	real _norm;
+	real mass_above;
+};
+
+
+template<typename real>
+template<typename func>
+CDFEval<real>::CDFEval(const std::vector<real>& x, func F, const real xmin,
+                       const real xmax, const real outside_mass,
+                       const real dest_tol)
+   : intervals(std::max<size_t>(x.size(),1)+1), _norm(0.0)
+{
+	/* Typedefs: */
+	using boost::multiprecision::abs;
+	using std::abs;
+	using boost::math::quadrature::gauss_kronrod;
+	typedef gauss_kronrod<real, 7> GK;
+
+	const real eps_tol
+	   = boost::math::tools::root_epsilon<double>();
+
+	/* Setup all the intervals: */
+	const size_t N = x.size();
+	intervals[0].x = xmin;
+	intervals[0].cdf = 0.0;
+	if (N > 0){
+		for (size_t i=0; i<N; ++i){
+			intervals[i+1].x = x[i];
+		}
+	}
+	std::sort(intervals.begin(), intervals.end());
+	if (intervals.back().x > xmax || intervals.front().x < xmin)
+		throw std::runtime_error("One of the x values is out of bounds.");
+
+	/* Make sure that the intervals are finite: */
+	auto dest = intervals.begin();
+	for (auto from = intervals.cbegin(); from != intervals.cend(); ++from){
+		if (from->x == dest->x)
+			continue;
+		++dest;
+		*dest = *from;
+	}
+	intervals.resize((dest - intervals.begin()) + 1);
+
+	/* Integrate all the sub intervals: */
+	struct delta_error_t {
+		real y;
+		real yerr;
+	};
+	std::vector<delta_error_t> delta_err(intervals.size());
+	auto it_err = delta_err.begin();
+	typename std::vector<xy_t>::iterator it_next;
+	real cdf = 0.0;
+	for (auto it = intervals.begin(); it != intervals.end(); it = it_next){
+		/* Find the right boundary of the integration interval: */
+		it_next = it+1;
+		real xr = (it_next == intervals.end()) ? xmax : it_next->x;
+
+		/* Perform a one-shot Gauss-Kronrod quadrature: */
+		it_err->y = GK::integrate(F, it->x, xr, 0, eps_tol, &it_err->yerr);
+
+		/* Compute the cumulative sum: */
+		cdf += it_err->y;
+		if (it_next != intervals.end())
+			it_next->cdf = cdf;
+
+		++it_err;
+	}
+
+	/* Tail distribution: */
+	real tail = 0.0;
+	auto rit_err = delta_err.rbegin();
+	for (auto rit = intervals.rbegin(); rit != intervals.rend(); ++rit){
+		/* Since we start from the beyond-the-end xmax, the last
+		 * element is at the beginning of the interval and has
+		 * a tail distribution value equal to its integral.
+		 *
+		 * Each element gets assigned the current value of the tail
+		 * distribution.
+		 */
+		tail += rit_err->y;
+		rit->tail = tail;
+
+		++rit_err;
+	}
+
+	/* After the one-shot integration, investigate the errors. */
+	it_err = delta_err.begin();
+	cdf = 0.0;
+	real err = 0.0;
+	size_t refinements = 0;
+	for (auto it = intervals.begin(); it != intervals.end(); it = it_next){
+		it_next = it+1;
+
+		/* Check if we want to refine this integral: */
+		real compare = it->tail;
+		if (it_next != intervals.end())
+			compare = std::max(it_next->cdf, compare);
+
+		if (it_err->yerr > compare * dest_tol){
+			++refinements;
+
+			/* Find the right boundary of the integration interval: */
+			real xr = (it_next == intervals.end()) ? xmax : it_next->x;
+
+			real local_tol
+			   = std::max<real>(1e-2 * dest_tol * it->cdf / it_err->y,
+			                    eps_tol);
+			it_err->y = GK::integrate(F, it->x, xr, 8, local_tol,
+			                          &it_err->yerr);
+		}
+
+		/* Compute the cumulative sum: */
+		cdf += it_err->y;
+		if (it_next != intervals.end())
+			it_next->cdf = cdf;
+
+		/* Cumulative error: */
+		err += it_err->yerr;
+
+		++it_err;
+	}
+
+	/* Tail distribution, see above: */
+	tail = 0.0;
+	rit_err = delta_err.rbegin();
+	for (auto rit = intervals.rbegin(); rit != intervals.rend(); ++rit){
+		tail += rit_err->y;
+		rit->tail = tail;
+
+		++rit_err;
+	}
+
+	/* Norm: */
+	real scale = (outside_mass > 0) ? 1.0 / (cdf * (1.0 + outside_mass))
+	                                : 1.0 / cdf;
+	for (xy_t& xy : intervals){
+		xy.cdf *= scale;
+		xy.tail *= scale;
+		xy.tail += outside_mass;
+	}
+	_norm = cdf;
+
+	/* Error estimate (should be in the order of precision µ): */
+#ifdef DEBUG
+	real error = 0.0;
+	for (auto it = intervals.begin(); it != intervals.end(); ++it){
+		error = std::max(error, abs(it->tail - (1.0 - it->cdf)));
+	}
+	std::cout << "1 - (tail + cdf) error: " << error << "\n";
+#endif
+};
+
+
+template<typename real>
+real CDFEval<real>::cdf(const real& x) const
+{
+	/* Find the first element that is not smaller than x: */
+	auto it = std::lower_bound(intervals.cbegin(), intervals.cend(), x,
+	                           [](const xy_t& ele, const real& val) -> bool {
+	                               return ele.x < val;
+	                           }
+	);
+
+	/* Shortcut for out of bounds: */
+	if (it == intervals.cend()){
+		return 1.0;
+	}
+
+	/* Check if it's the desired value: */
+	if (it->x == x){
+		return it->cdf;
+	}
+
+	/* Shortcut for out of bounds: */
+	if (it == intervals.cbegin()){
+		return 0.0;
+	}
+
+	std::cout << std::setprecision(30);
+	std::cout << "before= " << (it-1)->x << "\n";
+	std::cout << "x =     " << x << "\n";
+	std::cout << "it->x = " << it->x << "\n";
+
+
+	throw std::runtime_error("CDFEval::cdf for non-prior-provided nodes not "
+	                         "implemented.");
+}
+
+
+template<typename real>
+real CDFEval<real>::tail(const real& x) const
+{
+	/* Find the first element that is not smaller than x: */
+	auto it = std::lower_bound(intervals.cbegin(), intervals.cend(), x,
+	                           [](const xy_t& ele, const real& val) -> bool {
+	                               return ele.x < val;
+	                           }
+	);
+
+	/* Shortcut for out of bounds: */
+	if (it == intervals.cend()){
+		return mass_above;
+	}
+
+	/* Check if it's the desired value: */
+	if (it->x == x){
+		return it->tail;
+	}
+
+	/* Shortcut for out of bounds: */
+	if (it == intervals.cbegin()){
+		return 1.0;
+	}
+
+	std::cout << std::setprecision(30);
+	std::cout << "before= " << (it-1)->x << "\n";
+	std::cout << "x =     " << x << "\n";
+	std::cout << "it->x = " << it->x << "\n";
+
+
+	throw std::runtime_error("CDFEval::tail for non-prior-provided nodes not "
+	                         "implemented.");
+}
+
+
+template<typename real>
+void CDFEval<real>::add_outside_mass(const real mass, bool above)
+{
+	if (above){
+		const real scale = 1.0 / (1.0 + mass);
+		for (xy_t& xy : intervals){
+			xy.cdf *= scale;
+			xy.tail *= scale;
+			xy.tail += mass;
+		}
+		mass_above = mass;
+	} else
+		throw std::runtime_error("not implemented.");
+
+#ifdef DEBUG
+	real error = 0.0;
+	for (auto it = intervals.begin(); it != intervals.end(); ++it){
+		error = std::max(error, abs(it->tail - (1.0 - it->cdf)));
+	}
+	std::cout << "1 - (tail + cdf) error: " << error << "\n";
+#endif
+}
+
+}
+
+#endif

--- a/include/numerics/cdfeval.hpp
+++ b/include/numerics/cdfeval.hpp
@@ -197,8 +197,11 @@ CDFEval<real>::CDFEval(const std::vector<real>& x, func F, const real xmin,
 	}
 
 	/* Norm: */
-	real scale = (outside_mass > 0) ? 1.0 / (cdf * (1.0 + outside_mass))
-	                                : 1.0 / cdf;
+	real scale;
+	if (outside_mass > 0)
+		scale = 1.0 / (cdf * (1.0 + outside_mass));
+	else
+		scale = 1.0 / cdf;
 	for (xy_t& xy : intervals){
 		xy.cdf *= scale;
 		xy.tail *= scale;

--- a/jupyter/REHEATFUNQ/zeal2022hf/geojson.py
+++ b/jupyter/REHEATFUNQ/zeal2022hf/geojson.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from math import isinf
+
 def write_polygon_geojson(fpath, lon, lat, data, fields='data', name='A GeoJSON file'):
     """
     Writes a GeoJSON file.

--- a/meson.build
+++ b/meson.build
@@ -57,9 +57,25 @@ sources_hfp = ['external/pdtoolbox/src/ziebarth2022a.cpp',
                'external/pdtoolbox/src/quantileinverter.cpp']
 dependencies_hfp = [openmp_dep, boost_dep]
 
+hfp_cpp_args = []
+hfp_link_args = []
+if get_option('anomaly_posterior_float128')
+    hfp_cpp_args += ['--std=gnu++20','']
+    hfp_link_args += ['-lquadmath']
+endif
+if get_option('anomaly_posterior_dec50')
+    hfp_cpp_args += ['-DREHEATFUNQ_ANOMALY_POSTERIOR_TYPE_BOOST_DEC_50']
+endif
+if get_option('anomaly_posterior_dec100')
+    hfp_cpp_args += ['-DREHEATFUNQ_ANOMALY_POSTERIOR_TYPE_BOOST_DEC_100']
+endif
+
+
 libhfp = static_library(
     'hfp', sources_hfp,
     dependencies : dependencies_hfp,
+    cpp_args : hfp_cpp_args,
+    link_args : hfp_link_args,
     include_directories : include
 )
 
@@ -115,7 +131,8 @@ python.extension_module('bayes',
                         dependencies : [dep_py],
                         include_directories : include,
                         override_options : ['cython_language=cpp'],
-                        link_with : libhfp)
+                        link_with : libhfp,
+                        link_args : hfp_link_args)
 
 python.extension_module('rdisks',
                         'reheatfunq/coverings/rdisks.pyx',

--- a/meson.build
+++ b/meson.build
@@ -60,7 +60,7 @@ dependencies_hfp = [openmp_dep, boost_dep]
 hfp_cpp_args = []
 hfp_link_args = []
 if get_option('anomaly_posterior_float128')
-    hfp_cpp_args += ['--std=gnu++20','']
+    hfp_cpp_args += ['--std=gnu++20','-DREHEATFUNQ_ANOMALY_POSTERIOR_TYPE_QUAD']
     hfp_link_args += ['-lquadmath']
 endif
 if get_option('anomaly_posterior_dec50')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,11 @@
+option('anomaly_posterior_float128', type : 'boolean', value : false,
+       description : 'Whether to support GCC 128bit floats in the anomaly ' +
+                     'quantification posterior.')
+option('anomaly_posterior_dec50', type : 'boolean', value : false,
+       description : 'Whether to support 50 digit boost multiprecision ' +
+                     'floating point numbers in the anomaly quantification ' +
+                     'posterior.')
+option('anomaly_posterior_dec100', type : 'boolean', value : false,
+       description : 'Whether to support 50 digit boost multiprecision ' +
+                     'floating point numbers in the anomaly quantification ' +
+                     'posterior.')

--- a/reheatfunq/anomaly/bayes.pyx
+++ b/reheatfunq/anomaly/bayes.pyx
@@ -5,7 +5,8 @@
 #
 # Author: Malte J. Ziebarth (ziebarth@gfz-potsdam.de)
 #
-# Copyright (C) 2022 Deutsches GeoForschungsZentrum GFZ
+# Copyright (C) 2022 Deutsches GeoForschungsZentrum GFZ,
+#               2022 Malte J. Ziebarth
 #
 # [1] Ziebarth, M. J., Anderson, J. G., von Specht, S., Heidbach, O., &
 #     Cotton, F. (submitted 2021). "Seismic Efficiency and Elastic Power
@@ -32,47 +33,88 @@ import numpy as np
 from libcpp cimport bool
 from libcpp.vector cimport vector
 
+# The higher precision arithmetics for the posterior-internal
+# code are activated via compile-time defines.
+# We grab them here for later querying in Python code:
+cdef extern from * namespace "reheatfunq::pydefines" nogil:
+    """
+    namespace reheatfunq {
+    namespace pydefines {
+    #ifdef REHEATFUNQ_ANOMALY_POSTERIOR_TYPE_QUAD
+    bool HAS_FLOAT128 = true;
+    #else
+    bool HAS_FLOAT128 = false;
+    #endif
+    #ifdef REHEATFUNQ_ANOMALY_POSTERIOR_TYPE_BOOST_DEC_50
+    bool HAS_DEC50 = true;
+    #else
+    bool HAS_DEC50 = false;
+    #endif
+    #ifdef REHEATFUNQ_ANOMALY_POSTERIOR_TYPE_BOOST_DEC_100
+    bool HAS_DEC100 = true;
+    #else
+    bool HAS_DEC100 = false;
+    #endif
+    }
+    }
+    """
+    bool HAS_FLOAT128
+    bool HAS_DEC50
+    bool HAS_DEC100
+
+
 cdef extern from "ziebarth2022a.hpp" namespace "pdtoolbox::heatflow" nogil:
+    enum precision_t:
+        WP_DOUBLE = 0
+        WP_LONG_DOUBLE = 1
+        WP_FLOAT_128 = 2
+        WP_BOOST_DEC_50 = 3
+        WP_BOOST_DEC_100 = 4
+
     void posterior_pdf(const double* x, long double* res, size_t Nx,
                        const double* qi, const double* ci, size_t N, double p,
                        double s, double n, double nu, double amin,
-                       double dest_tol) except+
+                       double dest_tol, precision_t wp) except+
 
     void posterior_pdf_batch(const double* x, size_t Nx, long double* res,
                              const vector[const double*]& qi,
                              const vector[const double*]& ci,
                              const vector[size_t]& N,
                              double p, double s, double n, double nu,
-                             double amin, double dest_tol) except+
+                             double amin, double dest_tol,
+                             precision_t wp) except+
 
     void posterior_cdf(const double* x, long double* res, size_t Nx,
                        const double* qi, const double* ci, size_t N, double p,
                        double s, double n, double nu, double amin,
-                       double dest_tol) except+
+                       double dest_tol, precision_t wp) except+
 
     void posterior_cdf_batch(const double* x, size_t Nx, long double* res,
                              const vector[const double*]& qi,
                              const vector[const double*]& ci,
                              const vector[size_t]& N,
                              double p, double s, double n, double nu,
-                             double amin, double dest_tol) except+
+                             double amin, double dest_tol,
+                             precision_t wp) except+
 
     void posterior_tail(const double* x, long double* res, size_t Nx,
                         const double* qi, const double* ci, size_t N, double p,
                         double s, double n, double nu, double amin,
-                        double dest_tol) except+
+                        double dest_tol, precision_t wp) except+
 
     void posterior_tail_batch(const double* x, size_t Nx, long double* res,
                               const vector[const double*]& qi,
                               const vector[const double*]& ci,
                               const vector[size_t]& N,
                               double p, double s, double n, double nu,
-                              double amin, double dest_tol) except+
+                              double amin, double dest_tol,
+                              precision_t wp) except+
 
     void posterior_log_unnormed(const double* x, long double* res, size_t Nx,
                                 const double* qi, const double* ci, size_t N,
                                 double p, double s, double n, double nu,
-                                double amin, double dest_tol) except+
+                                double amin, double dest_tol,
+                                precision_t wp) except+
 
     void tail_quantiles(const double* quantiles, double* res,
                         const size_t Nquant, const double* qi, const double* ci,
@@ -96,14 +138,63 @@ cdef extern from "ziebarth2022a.hpp" namespace "pdtoolbox::heatflow" nogil:
                                short print) except+
 
 
+def _support_float128():
+    return HAS_FLOAT128
+
+def _support_dec50():
+    return HAS_DEC50
+
+def _support_dec100():
+    return HAS_DEC100
+
+
+
+cdef precision_t get_working_precision(str working_precision, size_t M):
+    # Get the working precision.
+    if working_precision == 'auto':
+        # Decide depending on the number of data points.
+        if M > 500:
+            working_precision = 'long double'
+        else:
+            working_precision = 'double'
+    cdef precision_t wp
+    if working_precision == 'double':
+        wp = WP_DOUBLE
+    elif working_precision == 'long double':
+        wp = WP_LONG_DOUBLE
+    elif working_precision == 'float128':
+        wp = WP_FLOAT_128
+    elif working_precision == 'dec50':
+        wp = WP_BOOST_DEC_50
+    elif working_precision == 'dec100':
+        wp = WP_BOOST_DEC_100
+    else:
+        raise RuntimeError("Unknonw `working_precision` parameter given.")
+
+    return wp
+
 
 @cython.boundscheck(False)
 def marginal_posterior_pdf(double[::1] P_H, double p, double s, double n,
                            double v, const double[::1] qi, const double[::1] ci,
-                           double amin = 1.0, double dest_tol = 1e-8):
+                           double amin = 1.0, double dest_tol = 1e-8,
+                           str working_precision = 'auto'):
     """
     Computes the marginal posterior in total power Q̇ for a given set (s,n,v=ν,p)
     of prior parameters, heat flow measurements qi, and anomaly scalings ci.
+
+    Parameters
+    ----------
+    ...
+    working_precision : str, optional
+       Decides in which floating point precision the algorithm should work
+       internally. Must be one of 'double', 'long double', 'float128',
+       'dec50', 'dec100', or 'auto'. The standard C++ floating point numbers
+       are 'double' and 'long double'. The 'dec50' and 'dec100' options refer
+       to the boost multiprecision  50 and 100 decimal digit precision numbers,
+       respectively. The 'float128' implementation requires  REHEATFUNQ to be
+       compiled with the g++ 128bit floating point extension and the define
+       'REHEATFUNQ_ANOMALY_POSTERIOR_TYPE_QUAD' set.
     """
     # Step 0: Allocate the memory for evaluating the posterior:
     cdef long double[::1] z
@@ -116,10 +207,13 @@ def marginal_posterior_pdf(double[::1] P_H, double p, double s, double n,
                                   "(not implemented).")
     z = np.empty(N, dtype=np.longdouble)
 
+    # Working precision:
+    cdef precision_t wp = get_working_precision(working_precision, M)
+
     # Heavy lifting in C++:
     with nogil:
         posterior_pdf(&P_H[0], &z[0], N, &qi[0], &ci[0], M, p, s, n, v, amin,
-                      dest_tol)
+                      dest_tol, wp)
 
     return z.base
 
@@ -127,9 +221,23 @@ def marginal_posterior_pdf(double[::1] P_H, double p, double s, double n,
 @cython.boundscheck(False)
 def marginal_posterior_pdf_batch(const double[::1] P_H, double p, double s,
                                  double n, double v, list Qi, list Ci,
-                                 double amin = 1.0, double dest_tol = 1e-8):
+                                 double amin = 1.0, double dest_tol = 1e-8,
+                                 str working_precision = 'auto'):
     """
     ...
+
+    Parameters
+    ----------
+    ...
+    working_precision : str, optional
+       Decides in which floating point precision the algorithm should work
+       internally. Must be one of 'double', 'long double', 'float128',
+       'dec50', 'dec100', or 'auto'. The standard C++ floating point numbers
+       are 'double' and 'long double'. The 'dec50' and 'dec100' options refer
+       to the boost multiprecision  50 and 100 decimal digit precision numbers,
+       respectively. The 'float128' implementation requires  REHEATFUNQ to be
+       compiled with the g++ 128bit floating point extension and the define
+       'REHEATFUNQ_ANOMALY_POSTERIOR_TYPE_QUAD' set.
     """
     cdef size_t Nx = P_H.shape[0]
     cdef size_t Nqc = len(Qi)
@@ -140,6 +248,7 @@ def marginal_posterior_pdf_batch(const double[::1] P_H, double p, double s,
     cdef const double[::1] qi, ci
     cdef vector[const double*] qi_vec, ci_vec
     cdef vector[size_t] Nqc_i
+    cdef Mmax = 0
     qi_vec.resize(Nqc)
     ci_vec.resize(Nqc)
     Nqc_i.resize(Nqc)
@@ -149,14 +258,18 @@ def marginal_posterior_pdf_batch(const double[::1] P_H, double p, double s,
         qi_vec[i] = &qi[0]
         ci_vec[i] = &ci[0]
         Nqc_i[i] = qi.shape[0]
+        Mmax = max(qi.shape[0], Mmax)
         if ci.shape[0] != Nqc_i[i]:
             raise RuntimeError("In one sample, the shape of `qi` and `ci` do "
                                "not match.")
 
+    # Working precision:
+    cdef precision_t wp = get_working_precision(working_precision, Mmax)
+
     cdef long double[:,::1] res = np.empty((Nqc, Nx), dtype=np.longdouble)
     with nogil:
         posterior_pdf_batch(&P_H[0], Nx, &res[0,0], qi_vec, ci_vec, Nqc_i,
-                            p, s, n, v, amin, dest_tol)
+                            p, s, n, v, amin, dest_tol, wp)
 
     return res.base
 
@@ -165,11 +278,25 @@ def marginal_posterior_pdf_batch(const double[::1] P_H, double p, double s,
 @cython.boundscheck(False)
 def marginal_posterior_cdf(double[::1] P_H, double p, double s, double n,
                            double v, const double[::1] qi, const double[::1] ci,
-                           double amin = 1.0, double dest_tol=1e-8):
+                           double amin = 1.0, double dest_tol=1e-8,
+                           str working_precision = 'auto'):
     """
     Computes the marginal posterior cumulative distribution function in
     dissipated power P_H for a given set (s,n,v=ν,p) of prior parameters,
     heat flow measurements qi, and anomaly scalings ci.
+
+    Parameters
+    ----------
+    ...
+    working_precision : str, optional
+       Decides in which floating point precision the algorithm should work
+       internally. Must be one of 'double', 'long double', 'float128',
+       'dec50', 'dec100', or 'auto'. The standard C++ floating point numbers
+       are 'double' and 'long double'. The 'dec50' and 'dec100' options refer
+       to the boost multiprecision  50 and 100 decimal digit precision numbers,
+       respectively. The 'float128' implementation requires  REHEATFUNQ to be
+       compiled with the g++ 128bit floating point extension and the define
+       'REHEATFUNQ_ANOMALY_POSTERIOR_TYPE_QUAD' set.
     """
     # Step 0: Allocate the memory for evaluating the posterior:
     cdef long double[::1] z
@@ -182,10 +309,13 @@ def marginal_posterior_cdf(double[::1] P_H, double p, double s, double n,
                                   "(not implemented).")
     z = np.empty(N, dtype=np.longdouble)
 
+    # Working precision:
+    cdef precision_t wp = get_working_precision(working_precision, M)
+
     # Heavy lifting in C++:
     with nogil:
         posterior_cdf(&P_H[0], &z[0], N, &qi[0], &ci[0], M, p, s, n, v,
-                      amin, dest_tol)
+                      amin, dest_tol, wp)
 
     return z.base
 
@@ -193,9 +323,23 @@ def marginal_posterior_cdf(double[::1] P_H, double p, double s, double n,
 @cython.boundscheck(False)
 def marginal_posterior_cdf_batch(const double[::1] P_H, double p, double s,
                                  double n, double v, list Qi, list Ci,
-                                 double amin = 1.0, double dest_tol = 1e-8):
+                                 double amin = 1.0, double dest_tol = 1e-8,
+                                 str working_precision = 'auto'):
     """
     ...
+
+    Parameters
+    ----------
+    ...
+    working_precision : str, optional
+       Decides in which floating point precision the algorithm should work
+       internally. Must be one of 'double', 'long double', 'float128',
+       'dec50', 'dec100', or 'auto'. The standard C++ floating point numbers
+       are 'double' and 'long double'. The 'dec50' and 'dec100' options refer
+       to the boost multiprecision  50 and 100 decimal digit precision numbers,
+       respectively. The 'float128' implementation requires  REHEATFUNQ to be
+       compiled with the g++ 128bit floating point extension and the define
+       'REHEATFUNQ_ANOMALY_POSTERIOR_TYPE_QUAD' set.
     """
     cdef size_t Nx = P_H.shape[0]
     cdef size_t Nqc = len(Qi)
@@ -206,6 +350,7 @@ def marginal_posterior_cdf_batch(const double[::1] P_H, double p, double s,
     cdef const double[::1] qi, ci
     cdef vector[const double*] qi_vec, ci_vec
     cdef vector[size_t] Nqc_i
+    cdef size_t Mmax = 0
     qi_vec.resize(Nqc)
     ci_vec.resize(Nqc)
     Nqc_i.resize(Nqc)
@@ -215,14 +360,18 @@ def marginal_posterior_cdf_batch(const double[::1] P_H, double p, double s,
         qi_vec[i] = &qi[0]
         ci_vec[i] = &ci[0]
         Nqc_i[i] = qi.shape[0]
+        Mmax = max(qi.shape[0], Mmax)
         if ci.shape[0] != Nqc_i[i]:
             raise RuntimeError("In one sample, the shape of `qi` and `ci` do "
                                "not match.")
 
+    # Working precision:
+    cdef precision_t wp = get_working_precision(working_precision, Mmax)
+
     cdef long double[:,::1] res = np.empty((Nqc, Nx), dtype=np.longdouble)
     with nogil:
         posterior_cdf_batch(&P_H[0], Nx, &res[0,0], qi_vec, ci_vec, Nqc_i,
-                            p, s, n, v, amin, dest_tol)
+                            p, s, n, v, amin, dest_tol, wp)
 
     return res.base
 
@@ -231,11 +380,25 @@ def marginal_posterior_cdf_batch(const double[::1] P_H, double p, double s,
 def marginal_posterior_tail(double[::1] P_H, double p, double s, double n,
                             double v, const double[::1] qi,
                             const double[::1] ci,
-                            double amin = 1.0, double dest_tol = 1e-8):
+                            double amin = 1.0, double dest_tol = 1e-8,
+                            str working_precision = 'auto'):
     """
     Computes the marginal posterior cumulative distribution function in
     dissipated power P_H for a given set (s,n,v=ν,p) of prior parameters,
     heat flow measurements qi, and anomaly scalings ci.
+
+    Parameters
+    ----------
+    ...
+    working_precision : str, optional
+       Decides in which floating point precision the algorithm should work
+       internally. Must be one of 'double', 'long double', 'float128',
+       'dec50', 'dec100', or 'auto'. The standard C++ floating point numbers
+       are 'double' and 'long double'. The 'dec50' and 'dec100' options refer
+       to the boost multiprecision  50 and 100 decimal digit precision numbers,
+       respectively. The 'float128' implementation requires  REHEATFUNQ to be
+       compiled with the g++ 128bit floating point extension and the define
+       'REHEATFUNQ_ANOMALY_POSTERIOR_TYPE_QUAD' set.
     """
     # Step 0: Allocate the memory for evaluating the posterior:
     cdef long double[::1] z
@@ -247,12 +410,15 @@ def marginal_posterior_tail(double[::1] P_H, double p, double s, double n,
         raise NotImplementedError("No data given - use prior "
                                   "(not implemented).")
 
-        z = np.empty(N, dtype=np.longdouble)
+    z = np.empty(N, dtype=np.longdouble)
+
+    # Working precision:
+    cdef precision_t wp = get_working_precision(working_precision, M)
 
     # Heavy lifting in C++:
     with nogil:
         posterior_tail(&P_H[0], &z[0], N, &qi[0], &ci[0], M, p, s, n, v,
-                       amin, dest_tol)
+                       amin, dest_tol, wp)
 
     return z.base
 
@@ -260,9 +426,23 @@ def marginal_posterior_tail(double[::1] P_H, double p, double s, double n,
 @cython.boundscheck(False)
 def marginal_posterior_tail_batch(const double[::1] P_H, double p, double s,
                                   double n, double v, list Qi, list Ci,
-                                  double amin = 1.0, double dest_tol = 1e-8):
+                                  double amin = 1.0, double dest_tol = 1e-8,
+                                  str working_precision = 'auto'):
     """
     ...
+
+    Parameters
+    ----------
+    ...
+    working_precision : str, optional
+       Decides in which floating point precision the algorithm should work
+       internally. Must be one of 'double', 'long double', 'float128',
+       'dec50', 'dec100', or 'auto'. The standard C++ floating point numbers
+       are 'double' and 'long double'. The 'dec50' and 'dec100' options refer
+       to the boost multiprecision  50 and 100 decimal digit precision numbers,
+       respectively. The 'float128' implementation requires  REHEATFUNQ to be
+       compiled with the g++ 128bit floating point extension and the define
+       'REHEATFUNQ_ANOMALY_POSTERIOR_TYPE_QUAD' set.
     """
     cdef size_t Nx = P_H.shape[0]
     cdef size_t Nqc = len(Qi)
@@ -273,6 +453,7 @@ def marginal_posterior_tail_batch(const double[::1] P_H, double p, double s,
     cdef const double[::1] qi, ci
     cdef vector[const double*] qi_vec, ci_vec
     cdef vector[size_t] Nqc_i
+    cdef size_t Mmax = 0
     qi_vec.resize(Nqc)
     ci_vec.resize(Nqc)
     Nqc_i.resize(Nqc)
@@ -282,14 +463,18 @@ def marginal_posterior_tail_batch(const double[::1] P_H, double p, double s,
         qi_vec[i] = &qi[0]
         ci_vec[i] = &ci[0]
         Nqc_i[i] = qi.shape[0]
+        Mmax = max(qi.shape[0], Mmax)
         if ci.shape[0] != Nqc_i[i]:
             raise RuntimeError("In one sample, the shape of `qi` and `ci` do "
                                "not match.")
 
+    # Working precision:
+    cdef precision_t wp = get_working_precision(working_precision, Mmax)
+
     cdef long double[:,::1] res = np.empty((Nqc, Nx), dtype=np.longdouble)
     with nogil:
         posterior_tail_batch(&P_H[0], Nx, &res[0,0], qi_vec, ci_vec, Nqc_i,
-                             p, s, n, v, amin, dest_tol)
+                             p, s, n, v, amin, dest_tol, wp)
 
     return res.base
 
@@ -299,7 +484,8 @@ def marginal_posterior_tail_batch(const double[::1] P_H, double p, double s,
 def marginal_posterior_log_unnormed(double[::1] P_H, double p, double s,
                                     double n, double v, const double[::1] qi,
                                     const double[::1] ci, double epsabs = 1e-8,
-                                    double amin = 1.0, double dest_tol=1e-10):
+                                    double amin = 1.0, double dest_tol=1e-10,
+                                    str working_precision = 'auto'):
     """
     Computes the marginal posterior in dissipated power P_H for a given set
     (s,n,v=ν,p) of prior parameters, heat flow measurements qi, and anomaly
@@ -308,6 +494,19 @@ def marginal_posterior_log_unnormed(double[::1] P_H, double p, double s,
     Returns the logarithm of the unnormed pdf, i.e. the logarithm of the
     integral over the alpha and beta dimension. This makes it usable for
     adding a new dimension to the posterior and hence normalizing accordingly.
+
+    Parameters
+    ----------
+    ...
+    working_precision : str, optional
+       Decides in which floating point precision the algorithm should work
+       internally. Must be one of 'double', 'long double', 'float128',
+       'dec50', 'dec100', or 'auto'. The standard C++ floating point numbers
+       are 'double' and 'long double'. The 'dec50' and 'dec100' options refer
+       to the boost multiprecision  50 and 100 decimal digit precision numbers,
+       respectively. The 'float128' implementation requires  REHEATFUNQ to be
+       compiled with the g++ 128bit floating point extension and the define
+       'REHEATFUNQ_ANOMALY_POSTERIOR_TYPE_QUAD' set.
     """
     # Step 0: Allocate the memory for evaluating the posterior:
     cdef long double[::1] z
@@ -321,10 +520,13 @@ def marginal_posterior_log_unnormed(double[::1] P_H, double p, double s,
 
     z = np.empty(N, dtype=np.longdouble)
 
+    # Working precision:
+    cdef precision_t wp = get_working_precision(working_precision, M)
+
     # Heavy lifting in C++:
     with nogil:
         posterior_log_unnormed(&P_H[0], &z[0], N, &qi[0], &ci[0], M, p, s, n, v,
-                               amin, dest_tol)
+                               amin, dest_tol, wp)
 
     return z.base
 

--- a/reheatfunq/anomaly/bayes.pyx
+++ b/reheatfunq/anomaly/bayes.pyx
@@ -33,43 +33,43 @@ from libcpp cimport bool
 from libcpp.vector cimport vector
 
 cdef extern from "ziebarth2022a.hpp" namespace "pdtoolbox::heatflow" nogil:
-    void posterior_pdf(const double* x, double* res, size_t Nx,
+    void posterior_pdf(const double* x, long double* res, size_t Nx,
                        const double* qi, const double* ci, size_t N, double p,
                        double s, double n, double nu, double amin,
                        double dest_tol) except+
 
-    void posterior_pdf_batch(const double* x, size_t Nx, double* res,
+    void posterior_pdf_batch(const double* x, size_t Nx, long double* res,
                              const vector[const double*]& qi,
                              const vector[const double*]& ci,
                              const vector[size_t]& N,
                              double p, double s, double n, double nu,
                              double amin, double dest_tol) except+
 
-    void posterior_cdf(const double* x, double* res, size_t Nx,
+    void posterior_cdf(const double* x, long double* res, size_t Nx,
                        const double* qi, const double* ci, size_t N, double p,
                        double s, double n, double nu, double amin,
                        double dest_tol) except+
 
-    void posterior_cdf_batch(const double* x, size_t Nx, double* res,
+    void posterior_cdf_batch(const double* x, size_t Nx, long double* res,
                              const vector[const double*]& qi,
                              const vector[const double*]& ci,
                              const vector[size_t]& N,
                              double p, double s, double n, double nu,
                              double amin, double dest_tol) except+
 
-    void posterior_tail(const double* x, double* res, size_t Nx,
+    void posterior_tail(const double* x, long double* res, size_t Nx,
                         const double* qi, const double* ci, size_t N, double p,
                         double s, double n, double nu, double amin,
                         double dest_tol) except+
 
-    void posterior_tail_batch(const double* x, size_t Nx, double* res,
+    void posterior_tail_batch(const double* x, size_t Nx, long double* res,
                               const vector[const double*]& qi,
                               const vector[const double*]& ci,
                               const vector[size_t]& N,
                               double p, double s, double n, double nu,
                               double amin, double dest_tol) except+
 
-    void posterior_log_unnormed(const double* x, double* res, size_t Nx,
+    void posterior_log_unnormed(const double* x, long double* res, size_t Nx,
                                 const double* qi, const double* ci, size_t N,
                                 double p, double s, double n, double nu,
                                 double amin, double dest_tol) except+
@@ -100,14 +100,13 @@ cdef extern from "ziebarth2022a.hpp" namespace "pdtoolbox::heatflow" nogil:
 @cython.boundscheck(False)
 def marginal_posterior_pdf(double[::1] P_H, double p, double s, double n,
                            double v, const double[::1] qi, const double[::1] ci,
-                           double amin = 1.0, double dest_tol = 1e-8,
-                           bool inplace=False):
+                           double amin = 1.0, double dest_tol = 1e-8):
     """
     Computes the marginal posterior in total power Q̇ for a given set (s,n,v=ν,p)
     of prior parameters, heat flow measurements qi, and anomaly scalings ci.
     """
     # Step 0: Allocate the memory for evaluating the posterior:
-    cdef double[::1] z
+    cdef long double[::1] z
     cdef size_t N = P_H.shape[0], M=qi.shape[0]
     if qi.shape[0] != ci.shape[0]:
         raise RuntimeError("`qi` and `ci` have to be of same shape in "
@@ -115,10 +114,7 @@ def marginal_posterior_pdf(double[::1] P_H, double p, double s, double n,
     if M == 0:
         raise NotImplementedError("No data given - use prior "
                                   "(not implemented).")
-    if inplace:
-        z = P_H
-    else:
-        z = np.empty(N)
+    z = np.empty(N, dtype=np.longdouble)
 
     # Heavy lifting in C++:
     with nogil:
@@ -157,7 +153,7 @@ def marginal_posterior_pdf_batch(const double[::1] P_H, double p, double s,
             raise RuntimeError("In one sample, the shape of `qi` and `ci` do "
                                "not match.")
 
-    cdef double[:,::1] res = np.empty((Nqc, Nx))
+    cdef long double[:,::1] res = np.empty((Nqc, Nx), dtype=np.longdouble)
     with nogil:
         posterior_pdf_batch(&P_H[0], Nx, &res[0,0], qi_vec, ci_vec, Nqc_i,
                             p, s, n, v, amin, dest_tol)
@@ -169,15 +165,14 @@ def marginal_posterior_pdf_batch(const double[::1] P_H, double p, double s,
 @cython.boundscheck(False)
 def marginal_posterior_cdf(double[::1] P_H, double p, double s, double n,
                            double v, const double[::1] qi, const double[::1] ci,
-                           double amin = 1.0, double dest_tol=1e-8,
-                           bool inplace=False):
+                           double amin = 1.0, double dest_tol=1e-8):
     """
     Computes the marginal posterior cumulative distribution function in
     dissipated power P_H for a given set (s,n,v=ν,p) of prior parameters,
     heat flow measurements qi, and anomaly scalings ci.
     """
     # Step 0: Allocate the memory for evaluating the posterior:
-    cdef double[::1] z
+    cdef long double[::1] z
     cdef size_t N = P_H.shape[0], M=qi.shape[0]
     if qi.shape[0] != ci.shape[0]:
         raise RuntimeError("`qi` and `ci` have to be of same shape in "
@@ -185,10 +180,7 @@ def marginal_posterior_cdf(double[::1] P_H, double p, double s, double n,
     if M == 0:
         raise NotImplementedError("No data given - use prior "
                                   "(not implemented).")
-    if inplace:
-        z = P_H
-    else:
-        z = np.empty(N)
+    z = np.empty(N, dtype=np.longdouble)
 
     # Heavy lifting in C++:
     with nogil:
@@ -227,7 +219,7 @@ def marginal_posterior_cdf_batch(const double[::1] P_H, double p, double s,
             raise RuntimeError("In one sample, the shape of `qi` and `ci` do "
                                "not match.")
 
-    cdef double[:,::1] res = np.empty((Nqc, Nx))
+    cdef long double[:,::1] res = np.empty((Nqc, Nx), dtype=np.longdouble)
     with nogil:
         posterior_cdf_batch(&P_H[0], Nx, &res[0,0], qi_vec, ci_vec, Nqc_i,
                             p, s, n, v, amin, dest_tol)
@@ -239,15 +231,14 @@ def marginal_posterior_cdf_batch(const double[::1] P_H, double p, double s,
 def marginal_posterior_tail(double[::1] P_H, double p, double s, double n,
                             double v, const double[::1] qi,
                             const double[::1] ci,
-                            double amin = 1.0, double dest_tol = 1e-8,
-                            bool inplace=False):
+                            double amin = 1.0, double dest_tol = 1e-8):
     """
     Computes the marginal posterior cumulative distribution function in
     dissipated power P_H for a given set (s,n,v=ν,p) of prior parameters,
     heat flow measurements qi, and anomaly scalings ci.
     """
     # Step 0: Allocate the memory for evaluating the posterior:
-    cdef double[::1] z
+    cdef long double[::1] z
     cdef size_t N = P_H.shape[0], M=qi.shape[0]
     if qi.shape[0] != ci.shape[0]:
         raise RuntimeError("`qi` and `ci` have to be of same shape in "
@@ -255,10 +246,8 @@ def marginal_posterior_tail(double[::1] P_H, double p, double s, double n,
     if M == 0:
         raise NotImplementedError("No data given - use prior "
                                   "(not implemented).")
-    if inplace:
-        z = P_H
-    else:
-        z = np.empty(N)
+
+        z = np.empty(N, dtype=np.longdouble)
 
     # Heavy lifting in C++:
     with nogil:
@@ -297,7 +286,7 @@ def marginal_posterior_tail_batch(const double[::1] P_H, double p, double s,
             raise RuntimeError("In one sample, the shape of `qi` and `ci` do "
                                "not match.")
 
-    cdef double[:,::1] res = np.empty((Nqc, Nx))
+    cdef long double[:,::1] res = np.empty((Nqc, Nx), dtype=np.longdouble)
     with nogil:
         posterior_tail_batch(&P_H[0], Nx, &res[0,0], qi_vec, ci_vec, Nqc_i,
                              p, s, n, v, amin, dest_tol)
@@ -310,8 +299,7 @@ def marginal_posterior_tail_batch(const double[::1] P_H, double p, double s,
 def marginal_posterior_log_unnormed(double[::1] P_H, double p, double s,
                                     double n, double v, const double[::1] qi,
                                     const double[::1] ci, double epsabs = 1e-8,
-                                    double amin = 1.0, double dest_tol=1e-10,
-                                    bool inplace=False):
+                                    double amin = 1.0, double dest_tol=1e-10):
     """
     Computes the marginal posterior in dissipated power P_H for a given set
     (s,n,v=ν,p) of prior parameters, heat flow measurements qi, and anomaly
@@ -322,7 +310,7 @@ def marginal_posterior_log_unnormed(double[::1] P_H, double p, double s,
     adding a new dimension to the posterior and hence normalizing accordingly.
     """
     # Step 0: Allocate the memory for evaluating the posterior:
-    cdef double[::1] z
+    cdef long double[::1] z
     cdef size_t N = P_H.shape[0], M=qi.shape[0]
     if qi.shape[0] != ci.shape[0]:
         raise RuntimeError("`qi` and `ci` have to be of same shape in "
@@ -330,10 +318,8 @@ def marginal_posterior_log_unnormed(double[::1] P_H, double p, double s,
     if M == 0:
         raise NotImplementedError("No data given - use prior "
                                   "(not implemented).")
-    if inplace:
-        z = P_H
-    else:
-        z = np.empty(N)
+
+    z = np.empty(N, dtype=np.longdouble)
 
     # Heavy lifting in C++:
     with nogil:

--- a/reheatfunq/anomaly/posterior.py
+++ b/reheatfunq/anomaly/posterior.py
@@ -164,7 +164,8 @@ class HeatFlowAnomalyPosterior:
 
         # Heavy lifting:
         return marginal_posterior_pdf_batch(P_H, p, self.gcp.s, self.gcp.n,
-                                            self.gcp.v, Qi, Ci).mean(axis=0)
+                                            self.gcp.v, Qi, Ci,
+                                            self.gcp.amin).mean(axis=0)
 
 
     def cdf(self, P_H: ArrayLike) -> np.ndarray:
@@ -196,7 +197,8 @@ class HeatFlowAnomalyPosterior:
 
         # Heavy lifting:
         return marginal_posterior_cdf_batch(P_H, p, self.gcp.s, self.gcp.n,
-                                            self.gcp.v, Qi, Ci).mean(axis=0)
+                                            self.gcp.v, Qi, Ci,
+                                            self.gcp.amin).mean(axis=0)
 
 
     def tail(self, P_H: ArrayLike) -> np.ndarray:
@@ -229,7 +231,8 @@ class HeatFlowAnomalyPosterior:
 
         # Heavy lifting:
         return marginal_posterior_tail_batch(P_H, p, self.gcp.s, self.gcp.n,
-                                             self.gcp.v, Qi, Ci).mean(axis=0)
+                                             self.gcp.v, Qi, Ci,
+                                             self.gcp.amin).mean(axis=0)
 
 
     def tail_quantiles(self, quantiles: ArrayLike,
@@ -262,6 +265,7 @@ class HeatFlowAnomalyPosterior:
         Ci = [self.c[ids] for w,ids in self.bootstrap]
         return marginal_posterior_tail_quantiles_batch(quantiles, p, self.gcp.s,
                                                        self.gcp.n, self.gcp.v,
-                                                       Qi, Ci, float(dest_tol),
+                                                       Qi, Ci, self.gcp.amin,
+                                                       float(dest_tol),
                                                        inplace = True)
 

--- a/reheatfunq/anomaly/posterior.py
+++ b/reheatfunq/anomaly/posterior.py
@@ -26,7 +26,19 @@ from ..regional import GammaConjugatePrior
 from ..coverings.rdisks import bootstrap_data_selection
 from .bayes import marginal_posterior_pdf_batch, marginal_posterior_cdf_batch, \
                    marginal_posterior_tail_batch, \
-                   marginal_posterior_tail_quantiles_batch
+                   marginal_posterior_tail_quantiles_batch, \
+                   _support_float128, _support_dec50, _support_dec100
+
+
+# Define the capabilities of the numerical backend:
+_num_prec = ['auto','double','long double']
+if _support_float128():
+    _num_prec.append('float128')
+if _support_dec50():
+    _num_prec.append('dec50')
+if _support_dec100():
+    _nume_prec.append('dec100')
+
 
 
 class HeatFlowAnomalyPosterior:
@@ -135,17 +147,30 @@ class HeatFlowAnomalyPosterior:
                          for w,sample in self.bootstrap)
 
 
-    def pdf(self, P_H: ArrayLike) -> np.ndarray:
+    def pdf(self, P_H: ArrayLike, dest_tol: float = 1e-8,
+            working_precision: Literal[_num_prec] = 'auto') -> np.ndarray:
         """
         Evaluate the marginal posterior distribution in
         heat-generating power :math:`P_H`.
 
         Parameters
         ----------
-
         P_H : array_like
               The powers (in W) at which to evaluate the
               marginal posterior density.
+        dest_tol : float, optional
+              The destination tolerance to use for the power
+              :math:`P_H` integration.
+        working_precision : 'auto' | 'double' | 'long double', optional
+              The precision of the internal numerical computations.
+              The higher the precision, the more likely it is to
+              obtain a precise result for large data sets. The
+              trade off is a longer run time.
+              If the respective flags have been set at compile
+              time, additional options 'float128' (GCC 128bit
+              floating point), 'dec50' (boost 50-digit multiprecision),
+              and 'dec100' (boost 100-digit multiprecision) are
+              available.
 
         Returns
         -------
@@ -168,17 +193,30 @@ class HeatFlowAnomalyPosterior:
                                             self.gcp.amin).mean(axis=0)
 
 
-    def cdf(self, P_H: ArrayLike) -> np.ndarray:
+    def cdf(self, P_H: ArrayLike, dest_tol: float = 1e-8,
+            working_precision: Literal[_num_prec] = 'auto') -> np.ndarray:
         """
         Evaluate the marginal posterior cumulative distribution
         of heat-generating power :math:`P_H`.
 
         Parameters
         ----------
-
         P_H : array_like
               The powers (in W) at which to evaluate the
               marginal posterior cumulative distribution.
+        dest_tol : float, optional
+              The destination tolerance to use for the power
+              :math:`P_H` integration.
+        working_precision : 'auto' | 'double' | 'long double', optional
+              The precision of the internal numerical computations.
+              The higher the precision, the more likely it is to
+              obtain a precise result for large data sets. The
+              trade off is a longer run time.
+              If the respective flags have been set at compile
+              time, additional options 'float128' (GCC 128bit
+              floating point), 'dec50' (boost 50-digit multiprecision),
+              and 'dec100' (boost 100-digit multiprecision) are
+              available.
 
         Returns
         -------
@@ -202,7 +240,8 @@ class HeatFlowAnomalyPosterior:
                    .mean(axis=0).astype(np.double)
 
 
-    def tail(self, P_H: ArrayLike) -> np.ndarray:
+    def tail(self, P_H: ArrayLike, dest_tol: float = 1e-8,
+             working_precision: Literal[_num_prec] = 'auto') -> np.ndarray:
         """
         Evaluate the posterior tail distribution (complementary
         cumulative distribution) of heat-generating power
@@ -210,10 +249,22 @@ class HeatFlowAnomalyPosterior:
 
         Parameters
         ----------
-
         P_H : array_like
               The powers (in W) at which to evaluate the
               marginal posterior tail distribution.
+        dest_tol : float, optional
+              The destination tolerance to use for the power
+              :math:`P_H` integration.
+        working_precision : 'auto' | 'double' | 'long double', optional
+              The precision of the internal numerical computations.
+              The higher the precision, the more likely it is to
+              obtain a precise result for large data sets. The
+              trade off is a longer run time.
+              If the respective flags have been set at compile
+              time, additional options 'float128' (GCC 128bit
+              floating point), 'dec50' (boost 50-digit multiprecision),
+              and 'dec100' (boost 100-digit multiprecision) are
+              available.
 
         Returns
         -------

--- a/reheatfunq/anomaly/posterior.py
+++ b/reheatfunq/anomaly/posterior.py
@@ -198,7 +198,8 @@ class HeatFlowAnomalyPosterior:
         # Heavy lifting:
         return marginal_posterior_cdf_batch(P_H, p, self.gcp.s, self.gcp.n,
                                             self.gcp.v, Qi, Ci,
-                                            self.gcp.amin).mean(axis=0)
+                                            self.gcp.amin)\
+                   .mean(axis=0).astype(np.double)
 
 
     def tail(self, P_H: ArrayLike) -> np.ndarray:
@@ -232,7 +233,8 @@ class HeatFlowAnomalyPosterior:
         # Heavy lifting:
         return marginal_posterior_tail_batch(P_H, p, self.gcp.s, self.gcp.n,
                                              self.gcp.v, Qi, Ci,
-                                             self.gcp.amin).mean(axis=0)
+                                             self.gcp.amin)\
+                   .mean(axis=0).astype(np.double)
 
 
     def tail_quantiles(self, quantiles: ArrayLike,

--- a/reheatfunq/anomaly/posterior.py
+++ b/reheatfunq/anomaly/posterior.py
@@ -37,7 +37,7 @@ if _support_float128():
 if _support_dec50():
     _num_prec.append('dec50')
 if _support_dec100():
-    _nume_prec.append('dec100')
+    _num_prec.append('dec100')
 
 
 

--- a/reheatfunq/regional/__init__.py
+++ b/reheatfunq/regional/__init__.py
@@ -19,3 +19,4 @@
 
 from .prior import GammaConjugatePrior, default_prior
 from .predictive import HeatFlowPredictive
+from .backend import gamma_mle

--- a/reheatfunq/regional/prior.py
+++ b/reheatfunq/regional/prior.py
@@ -19,7 +19,7 @@
 
 # Typing:
 from __future__ import annotations
-from typing import Iterable, Optional, Literal
+from typing import Iterable, Optional, Literal, Tuple
 from numpy.typing import ArrayLike
 
 import numpy as np

--- a/reheatfunq/resilience/zeal2022hfresil.pyx
+++ b/reheatfunq/resilience/zeal2022hfresil.pyx
@@ -63,7 +63,7 @@ cdef extern from "resilience.hpp" namespace "heatflowpaper" nogil:
                                  double P_MW, double K, double T,
                                  double quantile, double PRIOR_P,
                                  double PRIOR_S, double PRIOR_N,
-                                 double PRIOR_V, cbool verbose,
+                                 double PRIOR_V, double amin, cbool verbose,
                                  cbool show_failures, size_t seed,
                                  unsigned short nthread, double tol) except+
 
@@ -71,7 +71,7 @@ cdef extern from "resilience.hpp" namespace "heatflowpaper" nogil:
                                  double P_MW, double K, double T,
                                  const array_d41& quantile, double PRIOR_P,
                                  double PRIOR_S, double PRIOR_N,
-                                 double PRIOR_V, cbool verbose,
+                                 double PRIOR_V, double amin, cbool verbose,
                                  cbool show_failures, size_t seed,
                                  unsigned short nthread, double tol) except+
 
@@ -80,7 +80,7 @@ cdef extern from "resilience.hpp" namespace "heatflowpaper" nogil:
                                  double x1, double s1, double a1,
                                  const array_d4& quantile, double PRIOR_P,
                                  double PRIOR_S, double PRIOR_N,
-                                 double PRIOR_V, cbool verbose,
+                                 double PRIOR_V, double amin, cbool verbose,
                                  cbool show_failures, size_t seed,
                                  unsigned short nthread, double tol) except+
 
@@ -89,7 +89,7 @@ cdef extern from "resilience.hpp" namespace "heatflowpaper" nogil:
                                  double x1, double s1, double a1,
                                  const array_d41& quantile, double PRIOR_P,
                                  double PRIOR_S, double PRIOR_N,
-                                 double PRIOR_V, cbool verbose,
+                                 double PRIOR_V, double amin, cbool verbose,
                                  cbool show_failures, size_t seed,
                                  unsigned short nthread, double tol) except+
 
@@ -99,7 +99,8 @@ cdef extern from "resilience.hpp" namespace "heatflowpaper" nogil:
 def test_performance_cython(long[:] Nset, size_t M, double P_MW, double K,
                             double T, double[:] quantile, double PRIOR_P,
                             double PRIOR_S, double PRIOR_N, double PRIOR_V,
-                            short verbose=True, short show_failures=False,
+                            double amin = 1.0, short verbose=True,
+                            short show_failures=False,
                             size_t seed=848782, short use_cpp_quantiles=True,
                             double tol=1e-3, unsigned char nthread=0):
     """
@@ -132,6 +133,9 @@ def test_performance_cython(long[:] Nset, size_t M, double P_MW, double K,
         Parameter :math:`n` of the gamma conjugate prior.
     PRIOR_V : float
         Parameter :math:`\\nu` of the gamma conjugate prior.
+    amin : float
+        The minimum shape parameter :math:`\\alpha` of the gamma
+        distribution. Has to be positive.
     verbose : bool, optional
         If :python:`True`, print some progress information.
     show_failures : bool, optional
@@ -167,7 +171,7 @@ def test_performance_cython(long[:] Nset, size_t M, double P_MW, double K,
             with nogil:
                 result = test_performance_1q(Nset[i], M, P_MW, K,
                                              T, quantile[0], PRIOR_P, PRIOR_S,
-                                             PRIOR_N, PRIOR_V, verbose,
+                                             PRIOR_N, PRIOR_V, amin, verbose,
                                              show_failures, seed, nthread,
                                              tol)
                 for l in range(Nq):
@@ -186,7 +190,7 @@ def test_performance_cython(long[:] Nset, size_t M, double P_MW, double K,
             with nogil:
                 result = test_performance_41q(Nset[i], M, P_MW, K,
                                               T, quant41, PRIOR_P, PRIOR_S,
-                                              PRIOR_N, PRIOR_V, verbose,
+                                              PRIOR_N, PRIOR_V, amin, verbose,
                                               show_failures, seed, nthread,
                                               tol)
                 for l in range(Nq):
@@ -205,7 +209,7 @@ def test_performance_mixture_cython(long[:] Nset, size_t M, double P_MW,
                             double x0, double s0, double a0, double x1,
                             double s1, double a1, double[:] quantile,
                             double PRIOR_P, double PRIOR_S, double PRIOR_N,
-                            double PRIOR_V,  short verbose=True,
+                            double PRIOR_V,  double amin, short verbose=True,
                             short show_failures=False,
                             size_t seed=848782, short use_cpp_quantiles=True,
                             double tol=1e-3):
@@ -248,6 +252,9 @@ def test_performance_mixture_cython(long[:] Nset, size_t M, double P_MW,
         Parameter :math:`n` of the gamma conjugate prior.
     PRIOR_V : float
         Parameter :math:`\\nu` of the gamma conjugate prior.
+    amin : float
+        The minimum shape parameter :math:`\\alpha` of the gamma
+        distribution. Has to be positive.
     verbose : bool, optional
         If :python:`True`, print some progress information.
     show_failures : bool, optional
@@ -294,7 +301,7 @@ def test_performance_mixture_cython(long[:] Nset, size_t M, double P_MW,
             with nogil:
                 result = test_performance_mixture_4q(Nset[i], M, P_MW, x0, s0,
                                  a0, x1, s1, a1, quant4, PRIOR_P, PRIOR_S,
-                                 PRIOR_N, PRIOR_V, verbose, show_failures,
+                                 PRIOR_N, PRIOR_V, amin, verbose, show_failures,
                                  seed, 0, tol)
                 for l in range(Nq):
                     for j in range(M):
@@ -309,7 +316,7 @@ def test_performance_mixture_cython(long[:] Nset, size_t M, double P_MW,
             with nogil:
                 result = test_performance_mixture_41q(Nset[i], M, P_MW, x0,
                                  s0, a0, x1, s1, a1, quant41, PRIOR_P,
-                                 PRIOR_S, PRIOR_N, PRIOR_V, verbose,
+                                 PRIOR_S, PRIOR_N, PRIOR_V, amin, verbose,
                                  show_failures, seed, 0, tol)
                 for l in range(Nq):
                     for j in range(M):

--- a/testing/test_anomaly_posterior.py
+++ b/testing/test_anomaly_posterior.py
@@ -1,0 +1,239 @@
+# Test the numerics of the heat flow anomaly quantification posterior.
+#
+# Authors: Malte J. Ziebarth (ziebarth@gfz-potsdam.de)
+#
+# Copyright (C) 2022 Malte J. Ziebarth
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+from reheatfunq.regional.backend import gamma_mle
+from reheatfunq import HeatFlowAnomalyPosterior, AnomalyLS1980, \
+                       GammaConjugatePrior
+from reheatfunq.regional import default_prior
+from reheatfunq.anomaly.bayes import marginal_posterior_pdf
+
+
+def test_across_precisions_N50():
+    """
+    Use different numerical precisions to cross-validate the
+    numerics.
+    """
+    AnoPH = 100e6
+    N = 50
+
+    alpha = 40.
+    beta = 0.4
+
+    ano = AnomalyLS1980(np.array([(0, -80e3), (0, 80e3)]), 14e3)
+
+    rng = np.random.default_rng(29189)
+    Q = np.sort(rng.gamma(alpha, size=N) / beta)
+    x = 160e3 * (rng.random(size=N) - 0.5)
+    y = 160e3 * (rng.random(size=N) - 0.5)
+    xy = np.zeros((x.size,2))
+    xy[:,0] = x
+    xy[:,1] = y
+    q = Q + 1e3*ano(xy)
+
+    gcp = default_prior()
+
+    hfp = HeatFlowAnomalyPosterior(q, x, y, ano, gcp, 5.0e3)
+
+    P_H = np.linspace(0, hfp.PHmax_global, 200)
+
+    pdf = []
+    cdf = []
+    tail = []
+    for wp in ['double','long double','dec50']:
+        pdf.append(hfp.pdf(P_H, working_precision=wp))
+        cdf.append(hfp.cdf(P_H, working_precision=wp))
+        tail.append(hfp.tail(P_H, working_precision=wp))
+
+    np.testing.assert_allclose(pdf[0], pdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(pdf[1], pdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(cdf[0], cdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(cdf[1], cdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(tail[0], tail[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(tail[1], tail[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(tail[2], 1.0 - cdf[2], rtol=0.0, atol=5e-16)
+
+
+def test_across_precisions_N100():
+    """
+    Use different numerical precisions to cross-validate the
+    numerics.
+    """
+    AnoPH = 100e6
+    N = 100
+
+    alpha = 40.
+    beta = 0.4
+
+    ano = AnomalyLS1980(np.array([(0, -80e3), (0, 80e3)]), 14e3)
+
+    rng = np.random.default_rng(29189)
+    Q = np.sort(rng.gamma(alpha, size=N) / beta)
+    x = 160e3 * (rng.random(size=N) - 0.5)
+    y = 160e3 * (rng.random(size=N) - 0.5)
+    xy = np.zeros((x.size,2))
+    xy[:,0] = x
+    xy[:,1] = y
+    q = Q + 1e3*ano(xy)
+
+    gcp = default_prior()
+
+    hfp = HeatFlowAnomalyPosterior(q, x, y, ano, gcp, 0.0e3)
+
+    P_H = np.linspace(0, hfp.PHmax_global, 200)
+
+    pdf = []
+    cdf = []
+    tail = []
+    for wp in ['double','long double','dec50']:
+        pdf.append(hfp.pdf(P_H, working_precision=wp))
+        cdf.append(hfp.cdf(P_H, working_precision=wp))
+        tail.append(hfp.tail(P_H, working_precision=wp))
+
+    np.testing.assert_allclose(pdf[0],pdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(pdf[1],pdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(cdf[0],cdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(cdf[1],cdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(tail[0],tail[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(tail[1],tail[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(tail[2], 1.0 - cdf[2], rtol=0.0, atol=1e-15)
+
+
+def test_across_precisions_N1000():
+    """
+    Use different numerical precisions to cross-validate the
+    numerics.
+    """
+    AnoPH = 100e6
+    N = 1000
+
+    alpha = 120.
+    beta = 4.
+
+    ano = AnomalyLS1980(np.array([(0, -80e3), (0, 80e3)]), 14e3)
+
+    rng = np.random.default_rng(294982299)
+    Q = np.sort(rng.gamma(alpha, size=N) / beta)
+    x = 160e3 * (rng.random(size=N) - 0.5)
+    y = 160e3 * (rng.random(size=N) - 0.5)
+    xy = np.zeros((x.size,2))
+    xy[:,0] = x
+    xy[:,1] = y
+    q = Q + 1e3*ano(xy)
+
+    gcp = default_prior()
+
+    hfp = HeatFlowAnomalyPosterior(q, x, y, ano, gcp, 0.0e3)
+
+    P_H = np.linspace(0, hfp.PHmax_global, 200)
+
+    pdf = []
+    cdf = []
+    tail = []
+    for wp in ['double','long double','dec50']:
+        pdf.append(hfp.pdf(P_H, working_precision=wp))
+        cdf.append(hfp.cdf(P_H, working_precision=wp))
+        tail.append(hfp.tail(P_H, working_precision=wp))
+
+    np.testing.assert_allclose(pdf[0],pdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(pdf[1],pdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(cdf[0],cdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(cdf[1],cdf[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(tail[0],tail[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(tail[1],tail[2], rtol=1e-14, atol=0.0)
+    np.testing.assert_allclose(tail[2], 1.0 - cdf[2], rtol=0.0, atol=2e-16)
+
+
+def test_absolute_values():
+    """
+    Test the numerics against some independent values computed with
+    MPMath quadrature at dps=50.
+    """
+    # The test configuration:
+    p = 2.5220172925228335
+    s = 15.373016724405591
+    n = 0.2184765374862465
+    v = 0.2184765374862465
+    q = [ 75.70255678,  76.18744121,  79.01339271,  89.41498501, 99.3258167,
+         100.00115816, 103.74341636, 106.24710206, 111.40302288, 126.80598511]
+    c = [3.74039144e-12, 8.63295937e-12, 3.28571247e-12, 6.02724571e-11,
+         3.95429084e-12, 2.38382437e-11, 4.73856217e-12, 1.22700220e-10,
+         4.76447511e-11, 1.43570283e-11]
+
+    # Test evaluation at:
+    PH = [0.0,
+          36079499986.49826,
+          72158999972.99652,
+          108238499959.49478,
+          144317999945.99304,
+          180397499932.4913,
+          216476999918.98956,
+          252556499905.48782,
+          288635999891.9861,
+          324715499878.4844,
+          360794999864.9826,
+          396874499851.48083,
+          432953999837.9791,
+          469033499824.4774,
+          505112999810.97565,
+          541192499797.4739,
+          577271999783.9722,
+          613351499770.4705,
+          649430999756.9688,
+          685510499743.4669,
+          721589999729.9652,
+          757669499716.4635,
+          793748999702.9617,
+          829828499689.46,
+          865907999675.9583]
+
+    # The example results, computed with (naive) MPMath integration:
+    results = [1.7241192897370277e-12,
+               2.2866977442930377e-12,
+               2.86091040565077e-12,
+               3.338331735964264e-12,
+               3.596531876975022e-12,
+               3.5496478248777957e-12,
+               3.1952036246173426e-12,
+               2.6217208227599387e-12,
+               1.967463772125419e-12,
+               1.3594235527807356e-12,
+               8.726156417316245e-13,
+               5.256399224439391e-13,
+               3.001457222977609e-13,
+               1.639673040751133e-13,
+               8.636160270923706e-14,
+               4.4112650124608125e-14,
+               2.1932762532396427e-14,
+               1.0628488370765047e-14,
+               5.012061349931154e-15,
+               2.28775249245078e-15,
+               9.995794781506387e-16,
+               4.090459293003127e-16,
+               1.4962216749276923e-16,
+               4.289599271464578e-17,
+               0.0]
+
+    # Now validate the REHEATFUNQ code:
+    pdf_compare = marginal_posterior_pdf(np.array(PH), p, s, n, v, np.array(q),
+                                         np.array(c), amin = 1.0,
+                                         dest_tol=1e-15,
+                                         working_precision = 'long double')
+
+    np.testing.assert_allclose(pdf_compare, results, rtol=1e-11)

--- a/testing/test_import.py
+++ b/testing/test_import.py
@@ -1,0 +1,26 @@
+# Test the numerics of the heat flow anomaly quantification posterior.
+#
+# Authors: Malte J. Ziebarth (ziebarth@gfz-potsdam.de)
+#
+# Copyright (C) 2022 Malte J. Ziebarth
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+def test_api_import():
+    from reheatfunq import AnomalyLS1980, HeatFlowAnomalyPosterior, \
+                           HeatFlowPredictive, GammaConjugatePrior
+    from reheatfunq.data import read_nghf
+    from reheatfunq.coverings import random_global_R_disk_coverings,\
+                           bootstrap_data_selection, conforming_data_selection
+    from reheatfunq.regional import gamma_mle


### PR DESCRIPTION
This improves the precision of the heat flow anomaly posterior numerics and adds multiple working precision choices.

#### Added
- Added different working precisions for the heat flow anomaly strength
  quantification.
- Make `gamma_mle` method available in `reheatfunq.regional`.
- Added `pytest` testing.
- Added missing import in `jupyter/REHEATFUNQ/zeahl22hf/geojson.py`.

#### Changed
- Fix typo leading to incomplete quadrature error estimate in `outer_integrand`.
- Use precision-dependent tolerance in heat flow anomaly posterior quadrature.
- Add Kahan summation for heat flow anomaly posterior local